### PR TITLE
Add: editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# Top-most EditorConfig file
+root = true
+
+# Set the default charset
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[Makefile]
+indent_style = tab


### PR DESCRIPTION
EditorConfig is a file format and collection of text editor plugins for maintaining consistent coding styles between different editors and IDEs. It's not tied to a specific programming language or development tool, making it versatile for various projects.

As this grf relies on `make` I would have the end of line style to be set to `lf` rather than `crlf`.