### PR TITLE
Codechange: remove all //begin and //end comments in pnml files

### DIFF
--- a/src/25-electric/6y2.pnml
+++ b/src/25-electric/6y2.pnml
@@ -1,4 +1,3 @@
-// Begin 6y2
 
 // Graphics
 
@@ -101,5 +100,4 @@ item (FEAT_TRAINS, _6y2) {
     }
 }
 
-// End 6Y2
 

--- a/src/25-electric/hxd1.pnml
+++ b/src/25-electric/hxd1.pnml
@@ -1,4 +1,3 @@
-// Begin HXD1
 
 // Graphics
 
@@ -84,5 +83,4 @@ item (FEAT_TRAINS, hxd1) {
     }
 }
 
-// End HXD1
 

--- a/src/25-electric/hxd11000.pnml
+++ b/src/25-electric/hxd11000.pnml
@@ -1,4 +1,3 @@
-//Begin HXD11000
 switch (FEAT_TRAINS, SELF, switch_hxd11000_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_HXD1_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, hxd11000) {
     }
 }
 
-// End HXD11000
 

--- a/src/25-electric/hxd1b.pnml
+++ b/src/25-electric/hxd1b.pnml
@@ -1,4 +1,3 @@
-//Begin HXD1B
 switch (FEAT_TRAINS, SELF, switch_hxd1b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_HXD1_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -88,5 +87,4 @@ item (FEAT_TRAINS, hxd1b) {
     }
 }
 
-// End HXD1B
 

--- a/src/25-electric/hxd1d.pnml
+++ b/src/25-electric/hxd1d.pnml
@@ -1,4 +1,3 @@
-//Begin HXD1D
 switch (FEAT_TRAINS, SELF, switch_hxd1d_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_HXD1_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -88,5 +87,4 @@ item (FEAT_TRAINS, hxd1d) {
     }
 }
 
-// End hxd1d
 

--- a/src/25-electric/hxd1f.pnml
+++ b/src/25-electric/hxd1f.pnml
@@ -1,4 +1,3 @@
-// Begin HXD1F
 
 // Graphics
 
@@ -118,5 +117,4 @@ item (FEAT_TRAINS, hxd1f) {
     }
 }
 
-// End HXD1F
 

--- a/src/25-electric/hxd3c.pnml
+++ b/src/25-electric/hxd3c.pnml
@@ -1,4 +1,3 @@
-// Begin HXD3C
 
 // Graphics
 
@@ -80,5 +79,4 @@ item (FEAT_TRAINS, hxd3c) {
     }
 }
 
-// End HXD3C
 

--- a/src/25-electric/hxd3d.pnml
+++ b/src/25-electric/hxd3d.pnml
@@ -1,4 +1,3 @@
-//Begin HXD3D
 switch (FEAT_TRAINS, SELF, switch_hxd3d_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_HXD3_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -88,5 +87,4 @@ item (FEAT_TRAINS, hxd3d) {
     }
 }
 
-// End HXD3D
 

--- a/src/25-electric/ss1.pnml
+++ b/src/25-electric/ss1.pnml
@@ -1,4 +1,3 @@
-// Begin SS1
 
 // Graphics
 
@@ -96,5 +95,4 @@ item (FEAT_TRAINS, ss1) {
     }
 }
 
-// End SS1
 

--- a/src/25-electric/ss3.pnml
+++ b/src/25-electric/ss3.pnml
@@ -1,4 +1,3 @@
-// Begin SS3
 
 // Graphics
 
@@ -81,5 +80,4 @@ item (FEAT_TRAINS, ss3) {
     }
 }
 
-// End SS3
 

--- a/src/25-electric/ss3b.pnml
+++ b/src/25-electric/ss3b.pnml
@@ -1,4 +1,3 @@
-// Begin SS3B
 
 // Graphics
 
@@ -85,5 +84,4 @@ item (FEAT_TRAINS, ss3b) {
     }
 }
 
-// End SS3B
 

--- a/src/25-electric/ss4.pnml
+++ b/src/25-electric/ss4.pnml
@@ -1,4 +1,3 @@
-// Begin SS4
 
 // Graphics
 
@@ -85,5 +84,4 @@ item (FEAT_TRAINS, ss4) {
     }
 }
 
-// End SS4
 

--- a/src/25-electric/ss4g.pnml
+++ b/src/25-electric/ss4g.pnml
@@ -1,4 +1,3 @@
-//Begin SS4G
 switch (FEAT_TRAINS, SELF, switch_ss4g_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_SS4_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, ss4g) {
     }
 }
 
-// End SS4G
 

--- a/src/25-electric/ss5.pnml
+++ b/src/25-electric/ss5.pnml
@@ -1,4 +1,3 @@
-// Begin SS5
 
 // Graphics
 
@@ -81,5 +80,4 @@ item (FEAT_TRAINS, ss5) {
     }
 }
 
-// End SS5
 

--- a/src/25-electric/ss6.pnml
+++ b/src/25-electric/ss6.pnml
@@ -1,4 +1,3 @@
-// Begin SS6
 
 // Graphics
 
@@ -81,5 +80,4 @@ item (FEAT_TRAINS, ss6) {
     }
 }
 
-// End SS3
 

--- a/src/25-electric/ss6b.pnml
+++ b/src/25-electric/ss6b.pnml
@@ -1,4 +1,3 @@
-//Begin SS6B
 switch (FEAT_TRAINS, SELF, switch_ss6b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_SS6_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -90,4 +89,3 @@ item (FEAT_TRAINS, ss6b) {
     }
 }
 
-// End SS6B

--- a/src/25-electric/ss7.pnml
+++ b/src/25-electric/ss7.pnml
@@ -1,4 +1,3 @@
-// Begin SS7
 
 // Graphics
 
@@ -82,4 +81,3 @@ item (FEAT_TRAINS, ss7) {
     }
 }
 
-// End SS7

--- a/src/25-electric/ss7b.pnml
+++ b/src/25-electric/ss7b.pnml
@@ -1,4 +1,3 @@
-//Begin SS7B
 switch (FEAT_TRAINS, SELF, switch_ss7b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_SS7_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -89,5 +88,4 @@ item (FEAT_TRAINS, ss7b) {
     }
 }
 
-// End SS7B
 

--- a/src/25-electric/ss7c.pnml
+++ b/src/25-electric/ss7c.pnml
@@ -1,4 +1,3 @@
-//Begin SS7C
 switch (FEAT_TRAINS, SELF, switch_ss7c_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_SS7_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -104,4 +103,3 @@ item (FEAT_TRAINS, ss7c) {
     }
 }
 
-// End SS7C

--- a/src/25-electric/ss7d.pnml
+++ b/src/25-electric/ss7d.pnml
@@ -1,4 +1,3 @@
-//Begin SS7D
 switch (FEAT_TRAINS, SELF, switch_ss7d_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_SS7_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -89,4 +88,3 @@ item (FEAT_TRAINS, ss7d) {
     }
 }
 
-// End SS7D

--- a/src/25-electric/ss7e.pnml
+++ b/src/25-electric/ss7e.pnml
@@ -1,4 +1,3 @@
-// Begin SS7E
 
 // Graphics
 
@@ -81,4 +80,3 @@ item (FEAT_TRAINS, ss7e) {
     }
 }
 
-// End SS7E

--- a/src/25-electric/ss8.pnml
+++ b/src/25-electric/ss8.pnml
@@ -1,4 +1,3 @@
-// Begin SS8
 
 // Graphics
 
@@ -81,5 +80,4 @@ item (FEAT_TRAINS, ss8) {
     }
 }
 
-// End SS8
 

--- a/src/25-electric/ss9.pnml
+++ b/src/25-electric/ss9.pnml
@@ -1,4 +1,3 @@
-// Begin SS9
 
 // Graphics
 
@@ -81,4 +80,3 @@ item (FEAT_TRAINS, ss9) {
     }
 }
 
-// End SS9

--- a/src/25-electric/ss9g.pnml
+++ b/src/25-electric/ss9g.pnml
@@ -1,4 +1,3 @@
-//Begin SS9G
 switch (FEAT_TRAINS, SELF, switch_ss9g_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_SS9_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -89,4 +88,3 @@ item (FEAT_TRAINS, ss9g) {
     }
 }
 
-// End SS9G

--- a/src/25-emu/cr200ja.pnml
+++ b/src/25-emu/cr200ja.pnml
@@ -1,4 +1,3 @@
-// Begin CR200JA
 switch (FEAT_TRAINS, SELF, switch_cr200ja_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CR200J_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -464,5 +463,4 @@ item (FEAT_TRAINS, cr200ja) {
     }
 }
 
-// End CR200JA
 

--- a/src/25-emu/cr200jal.pnml
+++ b/src/25-emu/cr200jal.pnml
@@ -1,4 +1,3 @@
-//Begin CR200JAL
 switch (FEAT_TRAINS, SELF, switch_cr200jal_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CR200J_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -368,5 +367,4 @@ item (FEAT_TRAINS, cr200jal) {
     }
 }
 
-// End CR200JAL
 

--- a/src/25-emu/cr200jb.pnml
+++ b/src/25-emu/cr200jb.pnml
@@ -1,4 +1,3 @@
-//Begin CR200JB
 switch (FEAT_TRAINS, SELF, switch_cr200jb_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CR200J_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -389,5 +388,4 @@ item (FEAT_TRAINS, cr200jb) {
     }
 }
 
-// End CR200JB
 

--- a/src/25-emu/cr200jc.pnml
+++ b/src/25-emu/cr200jc.pnml
@@ -1,4 +1,3 @@
-//Begin CR200JC
 switch (FEAT_TRAINS, SELF, switch_cr200jc_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CR200J_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -425,5 +424,4 @@ item (FEAT_TRAINS, cr200jc) {
     }
 }
 
-// End CR200JC
 

--- a/src/25-emu/cr200jcl.pnml
+++ b/src/25-emu/cr200jcl.pnml
@@ -1,4 +1,3 @@
-//Begin CR200JCL
 switch (FEAT_TRAINS, SELF, switch_cr200jcl_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CR200J_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -299,4 +298,3 @@ item (FEAT_TRAINS, cr200jcl) {
     }
 }
 
-// End CR200JCL

--- a/src/25-emu/cr300af.pnml
+++ b/src/25-emu/cr300af.pnml
@@ -1,4 +1,3 @@
-// Begin  CR300AF
 
 // Graphics
 
@@ -365,5 +364,4 @@ item (FEAT_TRAINS, cr300af) {
     }
 }
 
-// End cr300af
 

--- a/src/25-emu/cr300bf.pnml
+++ b/src/25-emu/cr300bf.pnml
@@ -1,4 +1,3 @@
-// Begin CR300BF
 
 // Graphics
 
@@ -444,5 +443,4 @@ item (FEAT_TRAINS, cr300bf) {
     }
 }
 
-// End CR300BF
 

--- a/src/25-emu/cr400af.pnml
+++ b/src/25-emu/cr400af.pnml
@@ -1,4 +1,3 @@
-// Begin CR400AF
 switch (FEAT_TRAINS, SELF, switch_cr400af_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CR400AF_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -755,4 +754,3 @@ item (FEAT_TRAINS, cr400af) {
     }
 }
 
-// End CR400AF

--- a/src/25-emu/cr400afab.pnml
+++ b/src/25-emu/cr400afab.pnml
@@ -1,4 +1,3 @@
-//Begin CR400AFAB
 switch (FEAT_TRAINS, SELF, switch_cr400afab_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CR400AF_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -371,4 +370,3 @@ item (FEAT_TRAINS, cr400afab) {
     }
 }
 
-// End CR400AFAB

--- a/src/25-emu/cr400afabz.pnml
+++ b/src/25-emu/cr400afabz.pnml
@@ -1,4 +1,3 @@
-//Begin CR400AFABZ
 switch (FEAT_TRAINS, SELF, switch_cr400afabz_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CR400AF_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -418,4 +417,3 @@ item (FEAT_TRAINS, cr400afabz) {
     }
 }
 
-// End CR400AFABZ

--- a/src/25-emu/cr400afz.pnml
+++ b/src/25-emu/cr400afz.pnml
@@ -1,4 +1,3 @@
-//Begin CR400AFZ
 switch (FEAT_TRAINS, SELF, switch_cr400afz_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CR400AF_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -443,4 +442,3 @@ item (FEAT_TRAINS, cr400afz) {
     }
 }
 
-// End CR400AFZ

--- a/src/25-emu/cr400bf.pnml
+++ b/src/25-emu/cr400bf.pnml
@@ -1,4 +1,3 @@
-// Begin CR400BF
 switch (FEAT_TRAINS, SELF, switch_cr400bf_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CR400BF_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -370,4 +369,3 @@ item (FEAT_TRAINS, cr400bf) {
     }
 }
 
-// End CR400BF

--- a/src/25-emu/cr400bfab.pnml
+++ b/src/25-emu/cr400bfab.pnml
@@ -1,4 +1,3 @@
-//Begin CR400BFAB
 switch (FEAT_TRAINS, SELF, switch_cr400bfab_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CR400BF_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -331,4 +330,3 @@ item (FEAT_TRAINS, cr400bfab) {
     }
 }
 
-// End CR400BFAB

--- a/src/25-emu/crh1a.pnml
+++ b/src/25-emu/crh1a.pnml
@@ -1,4 +1,3 @@
-// Begin CRH1A
 switch (FEAT_TRAINS, SELF, switch_crh1a_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH1_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -361,5 +360,4 @@ item (FEAT_TRAINS, crh1a) {
     }
 }
 
-// End CRH1A
 

--- a/src/25-emu/crh1aa.pnml
+++ b/src/25-emu/crh1aa.pnml
@@ -1,4 +1,3 @@
-// Begin CRH1AA
 switch (FEAT_TRAINS, SELF, switch_crh1aa_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH1_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -339,4 +338,3 @@ item (FEAT_TRAINS, crh1aa) {
     }
 }
 
-// End CRH1AA

--- a/src/25-emu/crh1b.pnml
+++ b/src/25-emu/crh1b.pnml
@@ -1,4 +1,3 @@
-// Begin CRH1B
 switch (FEAT_TRAINS, SELF, switch_crh1b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH1_SERIES);
     return CB_RESULT_NO_TEXT;

--- a/src/25-emu/crh1e.pnml
+++ b/src/25-emu/crh1e.pnml
@@ -1,4 +1,3 @@
-//Begin CRH1E
 switch (FEAT_TRAINS, SELF, switch_crh1e_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH1_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -311,4 +310,3 @@ item (FEAT_TRAINS, crh1e) {
     }
 }
 
-// End CRH1E

--- a/src/25-emu/crh2a.pnml
+++ b/src/25-emu/crh2a.pnml
@@ -1,4 +1,3 @@
-// Begin crh2a
 switch (FEAT_TRAINS, SELF, switch_crh2a_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH2_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -478,5 +477,4 @@ item (FEAT_TRAINS, crh2a) {
     }
 }
 
-// End crh2a
 

--- a/src/25-emu/crh2b.pnml
+++ b/src/25-emu/crh2b.pnml
@@ -1,4 +1,3 @@
-//Begin CRH2B
 switch (FEAT_TRAINS, SELF, switch_crh2b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH2_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -367,4 +366,3 @@ item (FEAT_TRAINS, crh2b) {
     }
 }
 
-// End CRH2B

--- a/src/25-emu/crh2c.pnml
+++ b/src/25-emu/crh2c.pnml
@@ -1,4 +1,3 @@
-//Begin CRH2C
 switch (FEAT_TRAINS, SELF, switch_crh2c_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH2_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -420,5 +419,4 @@ item (FEAT_TRAINS, crh2c) {
     }
 }
 
-// End CRH2C
 

--- a/src/25-emu/crh2e.pnml
+++ b/src/25-emu/crh2e.pnml
@@ -1,4 +1,3 @@
-//Begin CRH2E
 switch (FEAT_TRAINS, SELF, switch_crh2e_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH2_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -396,4 +395,3 @@ item (FEAT_TRAINS, crh2e) {
     }
 }
 
-// End CRH2E

--- a/src/25-emu/crh2els.pnml
+++ b/src/25-emu/crh2els.pnml
@@ -1,4 +1,3 @@
-//Begin CRH2ELS
 switch (FEAT_TRAINS, SELF, switch_crh2els_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH2_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -256,4 +255,3 @@ item (FEAT_TRAINS, crh2els) {
     }
 }
 
-// End CRH2ELS

--- a/src/25-emu/crh2g.pnml
+++ b/src/25-emu/crh2g.pnml
@@ -1,4 +1,3 @@
-//Begin CRH2G
 switch (FEAT_TRAINS, SELF, switch_crh2g_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH2_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -412,4 +411,3 @@ item (FEAT_TRAINS, crh2g) {
     }
 }
 
-// End CRH2G

--- a/src/25-emu/crh380a.pnml
+++ b/src/25-emu/crh380a.pnml
@@ -1,4 +1,3 @@
-// Begin CRH380A
 switch (FEAT_TRAINS, SELF, switch_crh380a_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH380A_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -454,5 +453,4 @@ item (FEAT_TRAINS, crh380a) {
     }
 }
 
-// End CRH380A
 

--- a/src/25-emu/crh380al.pnml
+++ b/src/25-emu/crh380al.pnml
@@ -1,4 +1,3 @@
-//Begin CRH380AL
 switch (FEAT_TRAINS, SELF, switch_crh380al_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH380A_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -342,4 +341,3 @@ item (FEAT_TRAINS, crh380al) {
     }
 }
 
-// End CRH380AL

--- a/src/25-emu/crh380b.pnml
+++ b/src/25-emu/crh380b.pnml
@@ -1,4 +1,3 @@
-// Begin crh380b
 
 // Graphics
 
@@ -288,5 +287,4 @@ item (FEAT_TRAINS, crh380b) {
     }
 }
 
-// End crh380b
 

--- a/src/25-emu/crh380cl.pnml
+++ b/src/25-emu/crh380cl.pnml
@@ -1,4 +1,3 @@
-// Begin crh380cl
 
 // Graphics
 
@@ -283,5 +282,4 @@ item (FEAT_TRAINS, crh380cl) {
     }
 }
 
-// End crh380cl
 

--- a/src/25-emu/crh380d.pnml
+++ b/src/25-emu/crh380d.pnml
@@ -1,4 +1,3 @@
-// Begin CRH380D
 
 // Graphics
 
@@ -432,5 +431,4 @@ item (FEAT_TRAINS, crh380d) {
     }
 }
 
-// End CRH380D
 

--- a/src/25-emu/crh3a.pnml
+++ b/src/25-emu/crh3a.pnml
@@ -1,4 +1,3 @@
-// Begin CRH3A
 switch (FEAT_TRAINS, SELF, switch_crh3a_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH3_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -335,4 +334,3 @@ item (FEAT_TRAINS, crh3a) {
     }
 }
 
-// End CRH3A

--- a/src/25-emu/crh3c.pnml
+++ b/src/25-emu/crh3c.pnml
@@ -1,4 +1,3 @@
-//Begin CRH3C
 switch (FEAT_TRAINS, SELF, switch_crh3c_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH3_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -296,5 +295,4 @@ item (FEAT_TRAINS, crh3c) {
     }
 }
 
-// End crh3c
 

--- a/src/25-emu/crh5a.pnml
+++ b/src/25-emu/crh5a.pnml
@@ -1,4 +1,3 @@
-// Begin CRH5A
 
 // Graphics
 
@@ -414,5 +413,4 @@ item (FEAT_TRAINS, crh5a) {
     }
 }
 
-// End CRH5A
 

--- a/src/25-emu/crh6a2.pnml
+++ b/src/25-emu/crh6a2.pnml
@@ -1,4 +1,3 @@
-// Begin crh6a2
 switch (FEAT_TRAINS, SELF, switch_crh6a2_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH6_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -409,5 +408,4 @@ item (FEAT_TRAINS, crh6a2) {
     }
 }
 
-// End crh6a2
 

--- a/src/25-emu/crh6a3.pnml
+++ b/src/25-emu/crh6a3.pnml
@@ -1,4 +1,3 @@
-//Begin CRH6A3
 switch (FEAT_TRAINS, SELF, switch_crh6a3_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH6_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -241,5 +240,4 @@ item (FEAT_TRAINS, crh6a3) {
     }
 }
 
-// End CRH6A (3-Door)
 

--- a/src/25-emu/crh6aa.pnml
+++ b/src/25-emu/crh6aa.pnml
@@ -1,4 +1,3 @@
-//Begin CRH6AA
 switch (FEAT_TRAINS, SELF, switch_crh6aa_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH6_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -229,5 +228,4 @@ item (FEAT_TRAINS, crh6aa) {
     }
 }
 
-// End CRH6A-A (Section)
 

--- a/src/25-emu/crh6f.pnml
+++ b/src/25-emu/crh6f.pnml
@@ -1,4 +1,3 @@
-//Begin CRH6F
 switch (FEAT_TRAINS, SELF, switch_crh6f_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_CRH6_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -252,5 +251,4 @@ item (FEAT_TRAINS, crh6f) {
     }
 }
 
-// End CRH6F
 

--- a/src/25-emu/djj1.pnml
+++ b/src/25-emu/djj1.pnml
@@ -1,4 +1,3 @@
-// Begin DJJ1
 
 // Graphics
 
@@ -186,5 +185,4 @@ item (FEAT_TRAINS, djj1) {
     }
 }
 
-// End DJJ1
 

--- a/src/coaches/19/rw19k.pnml
+++ b/src/coaches/19/rw19k.pnml
@@ -1,4 +1,3 @@
-//Begin RW19K
 switch (FEAT_TRAINS, SELF, switch_rw19k_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25K_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -122,5 +121,4 @@ item (FEAT_TRAINS, rw19k) {
     }
 }
 
-// End RW19K
 

--- a/src/coaches/19/rw19t.pnml
+++ b/src/coaches/19/rw19t.pnml
@@ -1,4 +1,3 @@
-//Begin RW19T
 switch (FEAT_TRAINS, SELF, switch_rw19t_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25T_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,5 +90,4 @@ item (FEAT_TRAINS, rw19t) {
     }
 }
 
-// End RW19T
 

--- a/src/coaches/22/ca23.pnml
+++ b/src/coaches/22/ca23.pnml
@@ -1,4 +1,3 @@
-//Begin CA23
 switch (FEAT_TRAINS, SELF, switch_ca23_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -103,5 +102,4 @@ item (FEAT_TRAINS, ca23) {
     }
 }
 
-// End CA23
 

--- a/src/coaches/22/ca23aircon.pnml
+++ b/src/coaches/22/ca23aircon.pnml
@@ -1,4 +1,3 @@
-//Begin CA23AIRCON
 switch (FEAT_TRAINS, SELF, switch_ca23aircon_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_AIRCON_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -113,5 +112,4 @@ item (FEAT_TRAINS, ca23aircon) {
     }
 }
 
-// End CA23AIRCON
 

--- a/src/coaches/22/rw22.pnml
+++ b/src/coaches/22/rw22.pnml
@@ -1,4 +1,3 @@
-//Begin RW22
 switch (FEAT_TRAINS, SELF, switch_rw22_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -103,5 +102,4 @@ item (FEAT_TRAINS, rw22) {
     }
 }
 
-// End RW22
 

--- a/src/coaches/22/rw22aircon.pnml
+++ b/src/coaches/22/rw22aircon.pnml
@@ -1,4 +1,3 @@
-//Begin RW22AIRCON
 switch (FEAT_TRAINS, SELF, switch_rw22aircon_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_AIRCON_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -111,5 +110,4 @@ item (FEAT_TRAINS, rw22aircon) {
     }
 }
 
-// End RW22AIRCON
 

--- a/src/coaches/22/rz22.pnml
+++ b/src/coaches/22/rz22.pnml
@@ -1,4 +1,3 @@
-//Begin RZ22
 switch (FEAT_TRAINS, SELF, switch_rz22_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -103,5 +102,4 @@ item (FEAT_TRAINS, rz22) {
     }
 }
 
-// End RZ22
 

--- a/src/coaches/22/rz22aircon.pnml
+++ b/src/coaches/22/rz22aircon.pnml
@@ -1,4 +1,3 @@
-//Begin RZ22AIRCON
 switch (FEAT_TRAINS, SELF, switch_rz22aircon_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_AIRCON_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -111,5 +110,4 @@ item (FEAT_TRAINS, rz22aircon) {
     }
 }
 
-// End RZ22AIRCON
 

--- a/src/coaches/22/tz.pnml
+++ b/src/coaches/22/tz.pnml
@@ -1,4 +1,3 @@
-//Begin TZ
 switch (FEAT_TRAINS, SELF, switch_tz_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_AIRCON_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -112,5 +111,4 @@ item (FEAT_TRAINS, tz) {
     }
 }
 
-// End TZ
 

--- a/src/coaches/22/uz22.pnml
+++ b/src/coaches/22/uz22.pnml
@@ -1,4 +1,3 @@
-//Begin UZ22
 switch (FEAT_TRAINS, SELF, switch_uz22_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -117,5 +116,4 @@ item (FEAT_TRAINS, uz22) {
     }
 }
 
-// End UZ22
 

--- a/src/coaches/22/xl22.pnml
+++ b/src/coaches/22/xl22.pnml
@@ -1,4 +1,3 @@
-//Begin XL22
 switch (FEAT_TRAINS, SELF, switch_xl22_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -117,5 +116,4 @@ item (FEAT_TRAINS, xl22) {
     }
 }
 
-// End XL22
 

--- a/src/coaches/22/yw22.pnml
+++ b/src/coaches/22/yw22.pnml
@@ -1,4 +1,3 @@
-// Begin YW22
 switch (FEAT_TRAINS, SELF, switch_yw22_name_purchase, getbits(extra_callback_info1, 8, 8)) { 
     0: return string(STR_22_SERIES);
     1: return string(STR_NAME_YW22);
@@ -117,10 +116,8 @@ item (FEAT_TRAINS, yw22) {
     }
 }
 
-// End YW22
 
 
-// Begin YW221966
 
 item (FEAT_TRAINS, yw221966) {
     property {
@@ -182,4 +179,3 @@ item (FEAT_TRAINS, yw221966) {
     }
 }
 
-// End YW221966

--- a/src/coaches/22/yw22aircon.pnml
+++ b/src/coaches/22/yw22aircon.pnml
@@ -1,4 +1,3 @@
-//Begin YW22AIRCON
 switch (FEAT_TRAINS, SELF, switch_yw22aircon_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_AIRCON_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -111,5 +110,4 @@ item (FEAT_TRAINS, yw22aircon) {
     }
 }
 
-// End YW22AIRCON
 

--- a/src/coaches/22/yz22.pnml
+++ b/src/coaches/22/yz22.pnml
@@ -1,4 +1,3 @@
-// Begin YZ22
 switch (FEAT_TRAINS, SELF, switch_yz22_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -107,5 +106,4 @@ item (FEAT_TRAINS, yz22) {
     }
 }
 
-// End YZ22
 

--- a/src/coaches/22/yz22aircon.pnml
+++ b/src/coaches/22/yz22aircon.pnml
@@ -1,4 +1,3 @@
-// Begin YZ22AIRCON
 switch (FEAT_TRAINS, SELF, switch_yz22aircon_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_AIRCON_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -107,5 +106,4 @@ item (FEAT_TRAINS, yz22aircon) {
     }
 }
 
-// End YZ22AIRCON
 

--- a/src/coaches/22b/rw22b.pnml
+++ b/src/coaches/22b/rw22b.pnml
@@ -1,4 +1,3 @@
-//Begin RW22B
 switch (FEAT_TRAINS, SELF, switch_rw22b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22B_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,5 +90,4 @@ item (FEAT_TRAINS, rw22b) {
     }
 }
 
-// End RW22B
 

--- a/src/coaches/22b/yw22b.pnml
+++ b/src/coaches/22b/yw22b.pnml
@@ -1,4 +1,3 @@
-//Begin YW22B
 switch (FEAT_TRAINS, SELF, switch_yw22b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22B_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,5 +90,4 @@ item (FEAT_TRAINS, yw22b) {
     }
 }
 
-// End YW22B
 

--- a/src/coaches/22b/yz22b.pnml
+++ b/src/coaches/22b/yz22b.pnml
@@ -1,4 +1,3 @@
-// Begin YZ22B
 switch (FEAT_TRAINS, SELF, switch_yz22b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22B_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -87,5 +86,4 @@ item (FEAT_TRAINS, yz22b) {
     }
 }
 
-// End YZ22B
 

--- a/src/coaches/25/ca25ml.pnml
+++ b/src/coaches/25/ca25ml.pnml
@@ -1,4 +1,3 @@
-//Begin CA25ML
 switch (FEAT_TRAINS, SELF, switch_ca25ml_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -112,5 +111,4 @@ item (FEAT_TRAINS, ca25ml) {
     }
 }
 
-// End CA25ML
 

--- a/src/coaches/25/rw25ml.pnml
+++ b/src/coaches/25/rw25ml.pnml
@@ -1,4 +1,3 @@
-//Begin RW25ML
 switch (FEAT_TRAINS, SELF, switch_rw25ml_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -111,5 +110,4 @@ item (FEAT_TRAINS, rw25ml) {
     }
 }
 
-// End RW25ML
 

--- a/src/coaches/25/tz2.pnml
+++ b/src/coaches/25/tz2.pnml
@@ -1,4 +1,3 @@
-//Begin TZ2
 switch (FEAT_TRAINS, SELF, switch_tz2_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -107,5 +106,4 @@ item (FEAT_TRAINS, tz2) {
     }
 }
 
-// End TZ2
 

--- a/src/coaches/25/xl25ml.pnml
+++ b/src/coaches/25/xl25ml.pnml
@@ -1,4 +1,3 @@
-//Begin XL25ML
 switch (FEAT_TRAINS, SELF, switch_xl25ml_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -111,5 +110,4 @@ item (FEAT_TRAINS, xl25ml) {
     }
 }
 
-// End XL25ML
 

--- a/src/coaches/25/yw25ml.pnml
+++ b/src/coaches/25/yw25ml.pnml
@@ -1,4 +1,3 @@
-//Begin YW25ML
 switch (FEAT_TRAINS, SELF, switch_yw25ml_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -111,5 +110,4 @@ item (FEAT_TRAINS, yw25ml) {
     }
 }
 
-// End YW25ML
 

--- a/src/coaches/25/yz25ml.pnml
+++ b/src/coaches/25/yz25ml.pnml
@@ -1,4 +1,3 @@
-// Begin YZ25ML
 switch (FEAT_TRAINS, SELF, switch_yz25ml_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -107,5 +106,4 @@ item (FEAT_TRAINS, yz25ml) {
     }
 }
 
-// End YZ25ML
 

--- a/src/coaches/25b/rw25b.pnml
+++ b/src/coaches/25b/rw25b.pnml
@@ -1,4 +1,3 @@
-//Begin RW25B
 switch (FEAT_TRAINS, SELF, switch_rw25b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25B_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,5 +90,4 @@ item (FEAT_TRAINS, rw25b) {
     }
 }
 
-// End RW25B
 

--- a/src/coaches/25b/rz25b.pnml
+++ b/src/coaches/25b/rz25b.pnml
@@ -1,4 +1,3 @@
-//Begin RZ25B
 switch (FEAT_TRAINS, SELF, switch_rz25b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25B_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, rz25b) {
     }
 }
 
-// End RZ25B
 

--- a/src/coaches/25b/srw25bhd.pnml
+++ b/src/coaches/25b/srw25bhd.pnml
@@ -1,4 +1,3 @@
-//Begin SRW25BHD
 switch (FEAT_TRAINS, SELF, switch_srw25bhd_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25BHD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -75,5 +74,4 @@ item (FEAT_TRAINS, srw25bhd) {
     }
 }
 
-// End SRW25BHD
 

--- a/src/coaches/25b/srz25bhd.pnml
+++ b/src/coaches/25b/srz25bhd.pnml
@@ -1,4 +1,3 @@
-//Begin SRZ25BHD
 switch (FEAT_TRAINS, SELF, switch_srz25bhd_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25BHD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -75,5 +74,4 @@ item (FEAT_TRAINS, srz25bhd) {
     }
 }
 
-// End SRZ25BHD
 

--- a/src/coaches/25b/srz25bld.pnml
+++ b/src/coaches/25b/srz25bld.pnml
@@ -1,4 +1,3 @@
-//Begin SRZ25BLD
 switch (FEAT_TRAINS, SELF, switch_srz25bld_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25BLD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, srz25bld) {
     }
 }
 
-// End SRZ25BLD
 

--- a/src/coaches/25b/syw25bhd.pnml
+++ b/src/coaches/25b/syw25bhd.pnml
@@ -1,4 +1,3 @@
-//Begin SYW25BHD
 switch (FEAT_TRAINS, SELF, switch_syw25bhd_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25BHD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -75,5 +74,4 @@ item (FEAT_TRAINS, syw25bhd) {
     }
 }
 
-// End SYW25BHD
 

--- a/src/coaches/25b/syz25bhd.pnml
+++ b/src/coaches/25b/syz25bhd.pnml
@@ -1,4 +1,3 @@
-// Begin SYZ25BHD
 switch (FEAT_TRAINS, SELF, switch_syz25bhd_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25BHD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -107,5 +106,4 @@ item (FEAT_TRAINS, syz25bhd) {
     }
 }
 
-// End SYZ25BHD
 

--- a/src/coaches/25b/syz25bld.pnml
+++ b/src/coaches/25b/syz25bld.pnml
@@ -1,4 +1,3 @@
-// Begin SYZ25BLD
 switch (FEAT_TRAINS, SELF, switch_syz25bld_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25BLD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -117,5 +116,4 @@ item (FEAT_TRAINS, syz25bld) {
     }
 }
 
-// End SYZ25BLD
 

--- a/src/coaches/25b/xl25b.pnml
+++ b/src/coaches/25b/xl25b.pnml
@@ -1,4 +1,3 @@
-//Begin XL25B
 switch (FEAT_TRAINS, SELF, switch_xl25b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25B_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -120,5 +119,4 @@ item (FEAT_TRAINS, xl25b) {
     }
 }
 
-// End XL25B
 

--- a/src/coaches/25b/yw25b.pnml
+++ b/src/coaches/25b/yw25b.pnml
@@ -1,4 +1,3 @@
-//Begin YW25B
 switch (FEAT_TRAINS, SELF, switch_yw25b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25B_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, yw25b) {
     }
 }
 
-// End YW25B
 

--- a/src/coaches/25b/yz25b.pnml
+++ b/src/coaches/25b/yz25b.pnml
@@ -1,4 +1,3 @@
-// Begin YZ25B
 switch (FEAT_TRAINS, SELF, switch_yz25b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25B_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -110,5 +109,4 @@ item (FEAT_TRAINS, yz25b) {
     }
 }
 
-// End YZ25B
 

--- a/src/coaches/25dt/rw25dt_jinlun.pnml
+++ b/src/coaches/25dt/rw25dt_jinlun.pnml
@@ -1,4 +1,3 @@
-//Begin RW25DT_JINLUN
 switch (FEAT_TRAINS, SELF, switch_rw25dt_jinlun_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25DT_JINLUN_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -106,5 +105,4 @@ item (FEAT_TRAINS, rw25dt_jinlun) {
     }
 }
 
-// End RW25DT_JINLUN
 

--- a/src/coaches/25dt/srz25dt_jinlun.pnml
+++ b/src/coaches/25dt/srz25dt_jinlun.pnml
@@ -1,4 +1,3 @@
-//Begin SRZ25DT_JINLUN
 switch (FEAT_TRAINS, SELF, switch_srz25dt_jinlun_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25DT_JINLUN_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -106,5 +105,4 @@ item (FEAT_TRAINS, srz25dt_jinlun) {
     }
 }
 
-// End SRZ25DT_JINLUN
 

--- a/src/coaches/25dt/syz25dt_jinlun.pnml
+++ b/src/coaches/25dt/syz25dt_jinlun.pnml
@@ -1,4 +1,3 @@
-//Begin SYZ25DT_JINLUN
 switch (FEAT_TRAINS, SELF, switch_syz25dt_jinlun_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25DT_JINLUN_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -106,5 +105,4 @@ item (FEAT_TRAINS, syz25dt_jinlun) {
     }
 }
 
-// End SYZ25DT_JINLUN
 

--- a/src/coaches/25dt/yw25dt_jinlun.pnml
+++ b/src/coaches/25dt/yw25dt_jinlun.pnml
@@ -1,4 +1,3 @@
-//Begin YW25DT_JINLUN
 switch (FEAT_TRAINS, SELF, switch_yw25dt_jinlun_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25DT_JINLUN_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -106,5 +105,4 @@ item (FEAT_TRAINS, yw25dt_jinlun) {
     }
 }
 
-// End YW25DT_JINLUN
 

--- a/src/coaches/25dt/yz25dt_jinlun.pnml
+++ b/src/coaches/25dt/yz25dt_jinlun.pnml
@@ -1,4 +1,3 @@
-// Begin YZ25DT_JINLUN
 switch (FEAT_TRAINS, SELF, switch_yz25dt_jinlun_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25DT_JINLUN_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -101,5 +100,4 @@ item (FEAT_TRAINS, yz25dt_jinlun) {
     }
 }
 
-// End YZ25DT_JINLUN
 

--- a/src/coaches/25g/ca25g.pnml
+++ b/src/coaches/25g/ca25g.pnml
@@ -1,4 +1,3 @@
-//Begin CA25G
 switch (FEAT_TRAINS, SELF, switch_ca25g_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25G_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -120,5 +119,4 @@ item (FEAT_TRAINS, ca25g) {
     }
 }
 
-// End CA25G
 

--- a/src/coaches/25g/kd25g.pnml
+++ b/src/coaches/25g/kd25g.pnml
@@ -1,4 +1,3 @@
-//Begin KD25G
 switch (FEAT_TRAINS, SELF, switch_kd25g_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25G_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -125,5 +124,4 @@ item (FEAT_TRAINS, kd25g) {
     }
 }
 
-// End KD25G
 

--- a/src/coaches/25g/rw25g.pnml
+++ b/src/coaches/25g/rw25g.pnml
@@ -1,4 +1,3 @@
-//Begin RW25G
 switch (FEAT_TRAINS, SELF, switch_rw25g_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25G_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, rw25g) {
     }
 }
 
-// End RW25G
 

--- a/src/coaches/25g/rz25g.pnml
+++ b/src/coaches/25g/rz25g.pnml
@@ -1,4 +1,3 @@
-//Begin RZ25G
 switch (FEAT_TRAINS, SELF, switch_rz25g_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25G_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, rz25g) {
     }
 }
 
-// End RZ25G
 

--- a/src/coaches/25g/xl25g.pnml
+++ b/src/coaches/25g/xl25g.pnml
@@ -1,4 +1,3 @@
-//Begin XL25G
 switch (FEAT_TRAINS, SELF, switch_xl25g_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25G_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -106,5 +105,4 @@ item (FEAT_TRAINS, xl25g) {
     }
 }
 
-// End XL25G
 

--- a/src/coaches/25g/yw25g.pnml
+++ b/src/coaches/25g/yw25g.pnml
@@ -1,4 +1,3 @@
-//Begin YW25G
 switch (FEAT_TRAINS, SELF, switch_yw25g_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25G_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, yw25g) {
     }
 }
 
-// End YW25G
 

--- a/src/coaches/25g/yz25g.pnml
+++ b/src/coaches/25g/yz25g.pnml
@@ -1,4 +1,3 @@
-// Begin YZ25G
 switch (FEAT_TRAINS, SELF, switch_yz25g_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25G_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -115,5 +114,4 @@ item (FEAT_TRAINS, yz25g) {
     }
 }
 
-// End YZ25G
 

--- a/src/coaches/25k/ca25k.pnml
+++ b/src/coaches/25k/ca25k.pnml
@@ -1,4 +1,3 @@
-//Begin CA25K
 switch (FEAT_TRAINS, SELF, switch_ca25k_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25K_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, ca25k) {
     }
 }
 
-// End CA25K
 

--- a/src/coaches/25k/kd25k.pnml
+++ b/src/coaches/25k/kd25k.pnml
@@ -1,4 +1,3 @@
-//Begin KD25K
 switch (FEAT_TRAINS, SELF, switch_kd25k_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25K_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -115,5 +114,4 @@ item (FEAT_TRAINS, kd25k) {
     }
 }
 
-// End KD25K
 

--- a/src/coaches/25k/rw25k.pnml
+++ b/src/coaches/25k/rw25k.pnml
@@ -1,4 +1,3 @@
-//Begin RW25K
 switch (FEAT_TRAINS, SELF, switch_rw25k_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25K_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,5 +90,4 @@ item (FEAT_TRAINS, rw25k) {
     }
 }
 
-// End RW25K
 

--- a/src/coaches/25k/rz25k.pnml
+++ b/src/coaches/25k/rz25k.pnml
@@ -1,4 +1,3 @@
-//Begin RZ25K
 switch (FEAT_TRAINS, SELF, switch_rz25k_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25K_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,5 +90,4 @@ item (FEAT_TRAINS, rz25k) {
     }
 }
 
-// End RZ25K
 

--- a/src/coaches/25k/sca25khd.pnml
+++ b/src/coaches/25k/sca25khd.pnml
@@ -1,4 +1,3 @@
-//Begin SCA25KHD
 switch (FEAT_TRAINS, SELF, switch_sca25khd_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25KHD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, sca25khd) {
     }
 }
 
-// End SCA25KHD
 

--- a/src/coaches/25k/srw25khd.pnml
+++ b/src/coaches/25k/srw25khd.pnml
@@ -1,4 +1,3 @@
-//Begin SRW25KHD
 switch (FEAT_TRAINS, SELF, switch_srw25khd_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25KHD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -95,5 +94,4 @@ item (FEAT_TRAINS, srw25khd) {
     }
 }
 
-// End SRW25KHD
 

--- a/src/coaches/25k/srz25khd.pnml
+++ b/src/coaches/25k/srz25khd.pnml
@@ -1,4 +1,3 @@
-//Begin SRZ25KHD
 switch (FEAT_TRAINS, SELF, switch_srz25khd_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25KHD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -106,5 +105,4 @@ item (FEAT_TRAINS, srz25khd) {
     }
 }
 
-// End SRZ25KHD
 

--- a/src/coaches/25k/srz25kld.pnml
+++ b/src/coaches/25k/srz25kld.pnml
@@ -1,4 +1,3 @@
-//Begin SRZ25KLD
 switch (FEAT_TRAINS, SELF, switch_srz25kld_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25KLD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, srz25kld) {
     }
 }
 
-// End SRZ25KLD
 

--- a/src/coaches/25k/syw25khd.pnml
+++ b/src/coaches/25k/syw25khd.pnml
@@ -1,4 +1,3 @@
-//Begin SYW25KHD
 switch (FEAT_TRAINS, SELF, switch_syw25khd_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25KHD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -95,5 +94,4 @@ item (FEAT_TRAINS, syw25khd) {
     }
 }
 
-// End SYW25KHD
 

--- a/src/coaches/25k/syz25khd.pnml
+++ b/src/coaches/25k/syz25khd.pnml
@@ -1,4 +1,3 @@
-//Begin SYZ25KHD
 switch (FEAT_TRAINS, SELF, switch_syz25khd_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25KHD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -106,5 +105,4 @@ item (FEAT_TRAINS, syz25khd) {
     }
 }
 
-// End SYZ25KHD
 

--- a/src/coaches/25k/syz25kld.pnml
+++ b/src/coaches/25k/syz25kld.pnml
@@ -1,4 +1,3 @@
-// Begin SYZ25KLD
 switch (FEAT_TRAINS, SELF, switch_syz25kld_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25KLD_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -102,5 +101,4 @@ item (FEAT_TRAINS, syz25kld) {
     }
 }
 
-// End SYZ25KLD
 

--- a/src/coaches/25k/xl25k.pnml
+++ b/src/coaches/25k/xl25k.pnml
@@ -1,4 +1,3 @@
-//Begin XL25K
 switch (FEAT_TRAINS, SELF, switch_xl25k_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25K_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,5 +90,4 @@ item (FEAT_TRAINS, xl25k) {
     }
 }
 
-// End XL25K
 

--- a/src/coaches/25k/yw25k.pnml
+++ b/src/coaches/25k/yw25k.pnml
@@ -1,4 +1,3 @@
-//Begin YW25K
 switch (FEAT_TRAINS, SELF, switch_yw25k_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25K_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,5 +90,4 @@ item (FEAT_TRAINS, yw25k) {
     }
 }
 
-// End YW25K
 

--- a/src/coaches/25k/yz25k.pnml
+++ b/src/coaches/25k/yz25k.pnml
@@ -1,4 +1,3 @@
-// Begin YZ25K
 switch (FEAT_TRAINS, SELF, switch_yz25k_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25K_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -87,5 +86,4 @@ item (FEAT_TRAINS, yz25k) {
     }
 }
 
-// End YZ25K
 

--- a/src/coaches/25t/ca25t.pnml
+++ b/src/coaches/25t/ca25t.pnml
@@ -1,4 +1,3 @@
-//Begin CA25T
 switch (FEAT_TRAINS, SELF, switch_ca25t_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25T_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -116,5 +115,4 @@ item (FEAT_TRAINS, ca25t) {
     }
 }
 
-// End CA25T
 

--- a/src/coaches/25t/kd25t.pnml
+++ b/src/coaches/25t/kd25t.pnml
@@ -1,4 +1,3 @@
-//Begin KD25T
 switch (FEAT_TRAINS, SELF, switch_kd25t_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25T_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -87,5 +86,4 @@ item (FEAT_TRAINS, kd25t) {
     }
 }
 
-// End KD25T
 

--- a/src/coaches/25t/rw25t.pnml
+++ b/src/coaches/25t/rw25t.pnml
@@ -1,4 +1,3 @@
-//Begin RW25T
 switch (FEAT_TRAINS, SELF, switch_rw25t_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25T_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -126,5 +125,4 @@ item (FEAT_TRAINS, rw25t) {
     }
 }
 
-// End RW25T
 

--- a/src/coaches/25t/rz25t.pnml
+++ b/src/coaches/25t/rz25t.pnml
@@ -1,4 +1,3 @@
-//Begin RZ25T
 switch (FEAT_TRAINS, SELF, switch_rz25t_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25T_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -123,5 +122,4 @@ item (FEAT_TRAINS, rz25t) {
     }
 }
 
-// End RZ25T
 

--- a/src/coaches/25t/uz25t.pnml
+++ b/src/coaches/25t/uz25t.pnml
@@ -1,4 +1,3 @@
-//Begin UZ25T
 switch (FEAT_TRAINS, SELF, switch_uz25t_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25T_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -118,4 +117,3 @@ item (FEAT_TRAINS, uz25t) {
     }
 }
 
-// End UZ25T

--- a/src/coaches/25t/xl25t.pnml
+++ b/src/coaches/25t/xl25t.pnml
@@ -1,4 +1,3 @@
-//Begin XL25T
 switch (FEAT_TRAINS, SELF, switch_xl25t_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25T_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -124,5 +123,4 @@ item (FEAT_TRAINS, xl25t) {
     }
 }
 
-// End XL25T
 

--- a/src/coaches/25t/xl25t_sspe.pnml
+++ b/src/coaches/25t/xl25t_sspe.pnml
@@ -1,4 +1,3 @@
-//Begin XL25T_SSPE
 switch (FEAT_TRAINS, SELF, switch_xl25t_sspe_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25T_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,5 +90,4 @@ item (FEAT_TRAINS, xl25t_sspe) {
     }
 }
 
-// End XL25T_SSPE
 

--- a/src/coaches/25t/yw25t.pnml
+++ b/src/coaches/25t/yw25t.pnml
@@ -1,4 +1,3 @@
-//Begin YW25T
 switch (FEAT_TRAINS, SELF, switch_yw25t_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25T_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -118,5 +117,4 @@ item (FEAT_TRAINS, yw25t) {
     }
 }
 
-// End YW25T
 

--- a/src/coaches/25t/yz25t.pnml
+++ b/src/coaches/25t/yz25t.pnml
@@ -1,4 +1,3 @@
-// Begin YZ25T
 switch (FEAT_TRAINS, SELF, switch_yz25t_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_25T_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -117,5 +116,4 @@ item (FEAT_TRAINS, yz25t) {
     }
 }
 
-// End YZ25T
 

--- a/src/coaches/25z/ca25z.pnml
+++ b/src/coaches/25z/ca25z.pnml
@@ -1,4 +1,3 @@
-//Begin CA25Z
 switch (FEAT_TRAINS, SELF, switch_ca25z_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25Z_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -112,5 +111,4 @@ item (FEAT_TRAINS, ca25z) {
     }
 }
 
-// End CA25Z
 

--- a/src/coaches/25z/kd25z.pnml
+++ b/src/coaches/25z/kd25z.pnml
@@ -1,4 +1,3 @@
-//Begin KD25Z
 switch (FEAT_TRAINS, SELF, switch_kd25z_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25Z_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -107,5 +106,4 @@ item (FEAT_TRAINS, kd25z) {
     }
 }
 
-// End KD25Z
 

--- a/src/coaches/25z/rz125z.pnml
+++ b/src/coaches/25z/rz125z.pnml
@@ -1,4 +1,3 @@
-//Begin RZ125Z
 switch (FEAT_TRAINS, SELF, switch_rz125z_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25Z_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -117,4 +116,3 @@ item (FEAT_TRAINS, rz125z) {
     }
 }
 
-// End RZ125Z

--- a/src/coaches/25z/rz225z.pnml
+++ b/src/coaches/25z/rz225z.pnml
@@ -1,4 +1,3 @@
-// Begin RZ225Z
 switch (FEAT_TRAINS, SELF, switch_rz225z_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25Z_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -112,5 +111,4 @@ item (FEAT_TRAINS, rz225z) {
     }
 }
 
-// End SYZ25KLD
 

--- a/src/coaches/25z/rzt25z.pnml
+++ b/src/coaches/25z/rzt25z.pnml
@@ -1,4 +1,3 @@
-//Begin RZT25Z
 switch (FEAT_TRAINS, SELF, switch_rzt25z_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25Z_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,4 +90,3 @@ item (FEAT_TRAINS, rzt25z) {
     }
 }
 
-// End RZT25Z

--- a/src/coaches/25z/rzxl25z.pnml
+++ b/src/coaches/25z/rzxl25z.pnml
@@ -1,4 +1,3 @@
-//Begin RZXL25Z
 switch (FEAT_TRAINS, SELF, switch_rzxl25z_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25Z_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,4 +90,3 @@ item (FEAT_TRAINS, rzxl25z) {
     }
 }
 
-// End RZXL25Z

--- a/src/coaches/25z/sca25z.pnml
+++ b/src/coaches/25z/sca25z.pnml
@@ -1,4 +1,3 @@
-//Begin SCA25Z
 switch (FEAT_TRAINS, SELF, switch_sca25z_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25Z_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, sca25z) {
     }
 }
 
-// End SCA25Z
 

--- a/src/coaches/25z/srw25.pnml
+++ b/src/coaches/25z/srw25.pnml
@@ -1,4 +1,3 @@
-//Begin SRW25
 switch (FEAT_TRAINS, SELF, switch_srw25_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,4 +90,3 @@ item (FEAT_TRAINS, srw25) {
     }
 }
 
-// End SRW25

--- a/src/coaches/25z/srz125z.pnml
+++ b/src/coaches/25z/srz125z.pnml
@@ -1,4 +1,3 @@
-//Begin SRZ125Z
 switch (FEAT_TRAINS, SELF, switch_srz125z_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25Z_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -107,4 +106,3 @@ item (FEAT_TRAINS, srz125z) {
     }
 }
 
-// End SRZ125Z

--- a/src/coaches/25z/srz225z.pnml
+++ b/src/coaches/25z/srz225z.pnml
@@ -1,4 +1,3 @@
-// Begin SRZ225Z
 switch (FEAT_TRAINS, SELF, switch_srz225z_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25Z_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -102,5 +101,4 @@ item (FEAT_TRAINS, srz225z) {
     }
 }
 
-// End SRZ225Z
 

--- a/src/coaches/25z/srzxl25z.pnml
+++ b/src/coaches/25z/srzxl25z.pnml
@@ -1,4 +1,3 @@
-//Begin SRZXL25Z
 switch (FEAT_TRAINS, SELF, switch_srzxl25z_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25Z_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,4 +90,3 @@ item (FEAT_TRAINS, srzxl25z) {
     }
 }
 
-// End SRZXL25Z

--- a/src/coaches/25z/syw25.pnml
+++ b/src/coaches/25z/syw25.pnml
@@ -1,4 +1,3 @@
-// Begin SYW25
 switch (FEAT_TRAINS, SELF, switch_syw25_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_S25_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -89,4 +88,3 @@ item (FEAT_TRAINS, syw25) {
     }
 }
 
-// End SYW25

--- a/src/coaches/31/yz31.pnml
+++ b/src/coaches/31/yz31.pnml
@@ -1,4 +1,3 @@
-//Begin YZ31
 switch (FEAT_TRAINS, SELF, switch_yz31_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_22_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -102,5 +101,4 @@ item (FEAT_TRAINS, yz31) {
     }
 }
 
-// End YZ31
 

--- a/src/diesel/df.pnml
+++ b/src/diesel/df.pnml
@@ -1,4 +1,3 @@
-// Begin DF
 
 // Graphics
 
@@ -114,5 +113,4 @@ item (FEAT_TRAINS, df) {
     }
 }
 
-// End DF
 

--- a/src/diesel/df11.pnml
+++ b/src/diesel/df11.pnml
@@ -1,4 +1,3 @@
-// Begin DF11
 
 // Graphics
 
@@ -83,5 +82,4 @@ item (FEAT_TRAINS, df11) {
     }
 }
 
-// End DF11
 

--- a/src/diesel/df11g.pnml
+++ b/src/diesel/df11g.pnml
@@ -1,4 +1,3 @@
-// Begin DF11G
 
 // Graphics
 
@@ -135,5 +134,4 @@ item (FEAT_TRAINS, df11g) {
     }
 }
 
-// End DF11G
 

--- a/src/diesel/df11z.pnml
+++ b/src/diesel/df11z.pnml
@@ -1,4 +1,3 @@
-// Begin DF11Z
 
 // Graphics
 
@@ -84,5 +83,4 @@ item (FEAT_TRAINS, df11z) {
     }
 }
 
-// End DF11Z
 

--- a/src/diesel/df4bh.pnml
+++ b/src/diesel/df4bh.pnml
@@ -1,4 +1,3 @@
-//Begin DF4BH
 switch (FEAT_TRAINS, SELF, switch_df4bh_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF4_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -127,5 +126,4 @@ item (FEAT_TRAINS, df4bh) {
     }
 }
 
-// End DF4BH
 

--- a/src/diesel/df4bk.pnml
+++ b/src/diesel/df4bk.pnml
@@ -1,4 +1,3 @@
-//Begin DF4BK
 switch (FEAT_TRAINS, SELF, switch_df4bk_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF4_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -114,5 +113,4 @@ item (FEAT_TRAINS, df4bk) {
     }
 }
 
-// End DF4K
 

--- a/src/diesel/df4c.pnml
+++ b/src/diesel/df4c.pnml
@@ -1,4 +1,3 @@
-//Begin DF4C
 switch (FEAT_TRAINS, SELF, switch_df4c_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF4_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -106,5 +105,4 @@ item (FEAT_TRAINS, df4c) {
     }
 }
 
-// End DF4C
 

--- a/src/diesel/df4d0000.pnml
+++ b/src/diesel/df4d0000.pnml
@@ -1,4 +1,3 @@
-// Begin DF4D0000
 switch (FEAT_TRAINS, SELF, switch_df4d0000_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF4D_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -107,5 +106,4 @@ item (FEAT_TRAINS, df4d0000) {
     }
 }
 
-// End DF4D0000
 

--- a/src/diesel/df4d3000.pnml
+++ b/src/diesel/df4d3000.pnml
@@ -1,4 +1,3 @@
-//Begin DF4D3000
 switch (FEAT_TRAINS, SELF, switch_df4d3000_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF4D_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,5 +90,4 @@ item (FEAT_TRAINS, df4d3000) {
     }
 }
 
-// End DF4D3000
 

--- a/src/diesel/df4d4000.pnml
+++ b/src/diesel/df4d4000.pnml
@@ -1,4 +1,3 @@
-//Begin DF4D4000
 switch (FEAT_TRAINS, SELF, switch_df4d4000_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF4D_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -114,5 +113,4 @@ item (FEAT_TRAINS, df4d4000) {
     }
 }
 
-// End DF4D4000
 

--- a/src/diesel/df4d7000.pnml
+++ b/src/diesel/df4d7000.pnml
@@ -1,4 +1,3 @@
-//Begin DF4D7000
 switch (FEAT_TRAINS, SELF, switch_df4d7000_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF4D_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -91,5 +90,4 @@ item (FEAT_TRAINS, df4d7000) {
     }
 }
 
-// End DF4D7000
 

--- a/src/diesel/df4df.pnml
+++ b/src/diesel/df4df.pnml
@@ -1,4 +1,3 @@
-//Begin DF4DF
 switch (FEAT_TRAINS, SELF, switch_df4df_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF4D_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -106,5 +105,4 @@ item (FEAT_TRAINS, df4df) {
     }
 }
 
-// End DF4DF
 

--- a/src/diesel/df4e.pnml
+++ b/src/diesel/df4e.pnml
@@ -1,4 +1,3 @@
-// Begin DF4E
 
 // Graphics
 
@@ -102,5 +101,4 @@ item (FEAT_TRAINS, df4e) {
     }
 }
 
-// End DF4E
 

--- a/src/diesel/df4h.pnml
+++ b/src/diesel/df4h.pnml
@@ -1,4 +1,3 @@
-// Begin DF4H
 switch (FEAT_TRAINS, SELF, switch_df4h_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF4_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -92,5 +91,4 @@ item (FEAT_TRAINS, df4h) {
     }
 }
 
-// End DF4H
 

--- a/src/diesel/df4k.pnml
+++ b/src/diesel/df4k.pnml
@@ -1,4 +1,3 @@
-//Begin DF4K
 switch (FEAT_TRAINS, SELF, switch_df4k_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF4_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -150,5 +149,4 @@ item (FEAT_TRAINS, df4k) {
     }
 }
 
-// End DF4K
 

--- a/src/diesel/df5.pnml
+++ b/src/diesel/df5.pnml
@@ -1,4 +1,3 @@
-//Begin DF5
 switch (FEAT_TRAINS, SELF, switch_df5_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF5_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -116,5 +115,4 @@ item (FEAT_TRAINS, df5) {
     }
 }
 
-// End DF5
 

--- a/src/diesel/df5kz.pnml
+++ b/src/diesel/df5kz.pnml
@@ -1,4 +1,3 @@
-// Begin DF5KZ
 switch (FEAT_TRAINS, SELF, switch_df5kz_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF5_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -104,5 +103,4 @@ item (FEAT_TRAINS, df5kz) {
     }
 }
 
-// End DF5KZ
 

--- a/src/diesel/df7g.pnml
+++ b/src/diesel/df7g.pnml
@@ -1,4 +1,3 @@
-// Begin DF7G
 switch (FEAT_TRAINS, SELF, switch_df7g_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF7G_SERIES);
     return CB_RESULT_NO_TEXT;

--- a/src/diesel/df7g5000.pnml
+++ b/src/diesel/df7g5000.pnml
@@ -1,4 +1,3 @@
-//Begin DF7G5000
 switch (FEAT_TRAINS, SELF, switch_df7g5000_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF7G_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -103,5 +102,4 @@ item (FEAT_TRAINS, df7g5000) {
     }
 }
 
-// End DF7G5000
 

--- a/src/diesel/df7g8000.pnml
+++ b/src/diesel/df7g8000.pnml
@@ -1,4 +1,3 @@
-//Begin DF7G8000
 switch (FEAT_TRAINS, SELF, switch_df7g8000_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_DF7G_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -89,4 +88,3 @@ item (FEAT_TRAINS, df7g8000) {
     }
 }
 
-// End DF7G-8000

--- a/src/diesel/df8b.pnml
+++ b/src/diesel/df8b.pnml
@@ -1,4 +1,3 @@
-// Begin DF8B
 
 // Graphics
 
@@ -96,5 +95,4 @@ item (FEAT_TRAINS, df8b) {
     }
 }
 
-// End DF8B
 

--- a/src/diesel/dfh7.pnml
+++ b/src/diesel/dfh7.pnml
@@ -1,4 +1,3 @@
-// Begin DFH7
 
 // Graphics
 
@@ -106,4 +105,3 @@ item (FEAT_TRAINS, dfh7) {
     }
 }
 
-// End DFH7

--- a/src/diesel/hxn3.pnml
+++ b/src/diesel/hxn3.pnml
@@ -1,4 +1,3 @@
-// Begin HXN3
 switch (FEAT_TRAINS, SELF, switch_hxn3_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_HXN3_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -107,5 +106,4 @@ item (FEAT_TRAINS, hxn3) {
     }
 }
 
-// End HXN3
 

--- a/src/diesel/hxn3qz.pnml
+++ b/src/diesel/hxn3qz.pnml
@@ -1,4 +1,3 @@
-//Begin HXN3QZ
 switch (FEAT_TRAINS, SELF, switch_hxn3qz_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_HXN3_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -131,5 +130,4 @@ item (FEAT_TRAINS, hxn3qz) {
     }
 }
 
-// End HXN3QZ
 

--- a/src/diesel/hxn5.pnml
+++ b/src/diesel/hxn5.pnml
@@ -1,4 +1,3 @@
-// Begin HXN5
 switch (FEAT_TRAINS, SELF, switch_hxn5_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_HXN5_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -101,5 +100,4 @@ item (FEAT_TRAINS, hxn5) {
     }
 }
 
-// End HXN5
 

--- a/src/diesel/hxn5b.pnml
+++ b/src/diesel/hxn5b.pnml
@@ -1,4 +1,3 @@
-//Begin HXN5B
 switch (FEAT_TRAINS, SELF, switch_hxn5b_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_HXN5_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -89,4 +88,3 @@ item (FEAT_TRAINS, hxn5b) {
     }
 }
 
-// End HXN5B

--- a/src/diesel/nd5.pnml
+++ b/src/diesel/nd5.pnml
@@ -1,4 +1,3 @@
-// Begin ND5
 
 // Graphics
 
@@ -107,5 +106,4 @@ item (FEAT_TRAINS, nd5) {
     }
 }
 
-// End ND5
 

--- a/src/diesel/nj2.pnml
+++ b/src/diesel/nj2.pnml
@@ -1,4 +1,3 @@
-// Begin NJ2
 
 // Graphics
 
@@ -132,5 +131,4 @@ item (FEAT_TRAINS, nj2) {
     }
 }
 
-// End NJ2
 

--- a/src/dmu/nc3.pnml
+++ b/src/dmu/nc3.pnml
@@ -1,4 +1,3 @@
-// Begin NC3
 
 // Graphics
 
@@ -246,4 +245,3 @@ item (FEAT_TRAINS, nc3) {
     }
 }
 
-// End Nc3

--- a/src/dmu/ndj3.pnml
+++ b/src/dmu/ndj3.pnml
@@ -1,4 +1,3 @@
-// Begin NDJ3
 
 // Graphics
 
@@ -182,5 +181,4 @@ item (FEAT_TRAINS, ndj3) {
     }
 }
 
-// End NDJ3
 

--- a/src/dmu/nzj1_xinshuguang.pnml
+++ b/src/dmu/nzj1_xinshuguang.pnml
@@ -1,4 +1,3 @@
-// Begin NZJ1_Xinshuguang ("New Twilight")
 
 // Graphics
 
@@ -156,5 +155,4 @@ item (FEAT_TRAINS, nzj1_xinshuguang) {
     }
 }
 
-// End NZJ1_Xinshuguang
 

--- a/src/dmu/nzj2_jinlun_double_decker.pnml
+++ b/src/dmu/nzj2_jinlun_double_decker.pnml
@@ -1,4 +1,3 @@
-//Begin NZJ2_JINLUN_DOUBLE_DECKER
 switch (FEAT_TRAINS, SELF, switch_nzj2_jinlun_2_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_NZJ2_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -170,4 +169,3 @@ item (FEAT_TRAINS, nzj2_jinlun_2) {
     // }
 }
 
-// End NZJ2_JINLUN_DOUBLE_DECKER

--- a/src/dmu/nzj2_jinlun_unilaminar.pnml
+++ b/src/dmu/nzj2_jinlun_unilaminar.pnml
@@ -1,4 +1,3 @@
-// Begin NZJ2_JINLUN_UNILAMINAR
 switch (FEAT_TRAINS, SELF, switch_nzj2_jinlun_1_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_NZJ2_SERIES);
     return CB_RESULT_NO_TEXT;
@@ -166,4 +165,3 @@ item (FEAT_TRAINS, nzj2_jinlun_1) {
     // }
 }
 
-// End NZJ2_JINLUN_UNILAMINAR

--- a/src/steam/sy.pnml
+++ b/src/steam/sy.pnml
@@ -1,4 +1,3 @@
-// Begin SY
 
 // Graphics
 
@@ -86,5 +85,4 @@ item (FEAT_TRAINS, sy) {
     }
 }
 
-// End SY
 

--- a/src/template.pnml
+++ b/src/template.pnml
@@ -1,4 +1,3 @@
-// Begin template
 
 // Learned from JP+ Shinkansen
 

--- a/src/unit-wagons-rail/swmuw.pnml
+++ b/src/unit-wagons-rail/swmuw.pnml
@@ -1,4 +1,3 @@
-//Begin SWMUW
 switch (FEAT_TRAINS, SELF, switch_swmuw_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_MU_WAGON);
     return CB_RESULT_NO_TEXT;
@@ -71,5 +70,4 @@ item (FEAT_TRAINS, swmuw) {
     }
 }
 
-// End SWMUW
 

--- a/src/unit-wagons-rail/wemuw.pnml
+++ b/src/unit-wagons-rail/wemuw.pnml
@@ -1,4 +1,3 @@
-//Begin WEMUW
 switch (FEAT_TRAINS, SELF, switch_wemuw_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_MU_WAGON);
     return CB_RESULT_NO_TEXT;
@@ -72,5 +71,4 @@ item (FEAT_TRAINS, wemuw) {
     }
 }
 
-// End WEMUW
 

--- a/src/unit-wagons-rail/wgmuw.pnml
+++ b/src/unit-wagons-rail/wgmuw.pnml
@@ -1,4 +1,3 @@
-//Begin WGMUW
 switch (FEAT_TRAINS, SELF, switch_wgmuw_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_MU_WAGON);
     return CB_RESULT_NO_TEXT;
@@ -72,5 +71,4 @@ item (FEAT_TRAINS, wgmuw) {
     }
 }
 
-// End WGMUW
 

--- a/src/unit-wagons-rail/wymuw.pnml
+++ b/src/unit-wagons-rail/wymuw.pnml
@@ -1,4 +1,3 @@
-//Begin WYMUW
 switch (FEAT_TRAINS, SELF, switch_wymuw_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_MU_WAGON);
     return CB_RESULT_NO_TEXT;
@@ -72,5 +71,4 @@ item (FEAT_TRAINS, wymuw) {
     }
 }
 
-// End WYMUW
 

--- a/src/unit-wagons-rail/zecmuw.pnml
+++ b/src/unit-wagons-rail/zecmuw.pnml
@@ -1,4 +1,3 @@
-//Begin ZECMUW
 switch (FEAT_TRAINS, SELF, switch_zecmuw_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_MU_WAGON);
     return CB_RESULT_NO_TEXT;
@@ -73,5 +72,4 @@ item (FEAT_TRAINS, zecmuw) {
     }
 }
 
-// End ZECMUW
 

--- a/src/unit-wagons-rail/zemuw.pnml
+++ b/src/unit-wagons-rail/zemuw.pnml
@@ -1,4 +1,3 @@
-// Begin ZEMUW
 switch (FEAT_TRAINS, SELF, switch_zemuw_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_MU_WAGON);
     return CB_RESULT_NO_TEXT;
@@ -83,5 +82,4 @@ item (FEAT_TRAINS, zemuw) {
     }
 }
 
-// End ZEMUW
 

--- a/src/unit-wagons-rail/zsmuw.pnml
+++ b/src/unit-wagons-rail/zsmuw.pnml
@@ -1,4 +1,3 @@
-//Begin ZSMUW
 switch (FEAT_TRAINS, SELF, switch_zsmuw_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_MU_WAGON);
     return CB_RESULT_NO_TEXT;
@@ -72,5 +71,4 @@ item (FEAT_TRAINS, zsmuw) {
     }
 }
 
-// End ZSMUW
 

--- a/src/unit-wagons-rail/zymuw.pnml
+++ b/src/unit-wagons-rail/zymuw.pnml
@@ -1,4 +1,3 @@
-//Begin ZYMUW
 switch (FEAT_TRAINS, SELF, switch_zymuw_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_MU_WAGON);
     return CB_RESULT_NO_TEXT;
@@ -72,5 +71,4 @@ item (FEAT_TRAINS, zymuw) {
     }
 }
 
-// End ZYMUW
 

--- a/src/wagons/b22.pnml
+++ b/src/wagons/b22.pnml
@@ -1,4 +1,3 @@
-//Begin B22
 switch (FEAT_TRAINS, SELF, switch_b22_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_REFRIGERATOR_WAGON);
     return CB_RESULT_NO_TEXT;
@@ -106,5 +105,4 @@ item (FEAT_TRAINS, b22) {
     }
 }
 
-// End B22
 

--- a/src/wagons/b6.pnml
+++ b/src/wagons/b6.pnml
@@ -1,4 +1,3 @@
-// Begin B6
 switch (FEAT_TRAINS, SELF, switch_b6_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_REFRIGERATOR_WAGON);
     return CB_RESULT_NO_TEXT;
@@ -98,5 +97,4 @@ item (FEAT_TRAINS, b6) {
     }
 }
 
-// End B6
 

--- a/src/wagons/c62.pnml
+++ b/src/wagons/c62.pnml
@@ -1,4 +1,3 @@
-// Begin C62
 switch (FEAT_TRAINS, SELF, switch_c62_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_GONDOLA);
     return CB_RESULT_NO_TEXT;
@@ -117,5 +116,4 @@ item (FEAT_TRAINS, c62) {
     }
 }
 
-// End C62
 

--- a/src/wagons/c64.pnml
+++ b/src/wagons/c64.pnml
@@ -1,4 +1,3 @@
-//Begin C64
 switch (FEAT_TRAINS, SELF, switch_c64_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_GONDOLA);
     return CB_RESULT_NO_TEXT;
@@ -120,5 +119,4 @@ item (FEAT_TRAINS, c64) {
     }
 }
 
-// End C64
 

--- a/src/wagons/c70.pnml
+++ b/src/wagons/c70.pnml
@@ -1,4 +1,3 @@
-//Begin C70
 switch (FEAT_TRAINS, SELF, switch_c70_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_GONDOLA);
     return CB_RESULT_NO_TEXT;
@@ -147,5 +146,4 @@ item (FEAT_TRAINS, c70) {
     }
 }
 
-// End C70
 

--- a/src/wagons/g17.pnml
+++ b/src/wagons/g17.pnml
@@ -1,4 +1,3 @@
-//Begin G17
 switch (FEAT_TRAINS, SELF, switch_g17_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_TANKER);
     return CB_RESULT_NO_TEXT;
@@ -105,5 +104,4 @@ item (FEAT_TRAINS, g17) {
     }
 }
 
-// End G17
 

--- a/src/wagons/g50.pnml
+++ b/src/wagons/g50.pnml
@@ -1,4 +1,3 @@
-// Begin G50
 switch (FEAT_TRAINS, SELF, switch_g50_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_TANKER);
     return CB_RESULT_NO_TEXT;
@@ -87,5 +86,4 @@ item (FEAT_TRAINS, g50) {
     }
 }
 
-// End G50
 

--- a/src/wagons/g60.pnml
+++ b/src/wagons/g60.pnml
@@ -1,4 +1,3 @@
-//Begin G60
 switch (FEAT_TRAINS, SELF, switch_g60_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_TANKER);
     return CB_RESULT_NO_TEXT;
@@ -95,5 +94,4 @@ item (FEAT_TRAINS, g60) {
     }
 }
 
-// End G60
 

--- a/src/wagons/gn70.pnml
+++ b/src/wagons/gn70.pnml
@@ -1,4 +1,3 @@
-//Begin GN70
 switch (FEAT_TRAINS, SELF, switch_gn70_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_TANKER);
     return CB_RESULT_NO_TEXT;
@@ -99,5 +98,4 @@ item (FEAT_TRAINS, gn70) {
     }
 }
 
-// End GN70
 

--- a/src/wagons/gn80.pnml
+++ b/src/wagons/gn80.pnml
@@ -1,4 +1,3 @@
-//Begin GN80
 switch (FEAT_TRAINS, SELF, switch_gn80_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_TANKER);
     return CB_RESULT_NO_TEXT;
@@ -95,5 +94,4 @@ item (FEAT_TRAINS, gn80) {
     }
 }
 
-// End GN80
 

--- a/src/wagons/j5.pnml
+++ b/src/wagons/j5.pnml
@@ -1,4 +1,3 @@
-// Begin J5
 
 // Graphics
 
@@ -112,5 +111,4 @@ item (FEAT_TRAINS, j5) {
     }
 }
 
-// End J5
 

--- a/src/wagons/jsq5.pnml
+++ b/src/wagons/jsq5.pnml
@@ -1,4 +1,3 @@
-// Begin JSQ5
 switch (FEAT_TRAINS, SELF, switch_jsq5_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_VIHICLE_TRANSPORTER);
     return CB_RESULT_NO_TEXT;
@@ -94,5 +93,4 @@ item (FEAT_TRAINS, jsq5) {
     }
 }
 
-// End JSQ5
 

--- a/src/wagons/jsq6.pnml
+++ b/src/wagons/jsq6.pnml
@@ -1,4 +1,3 @@
-//Begin JSQ6
 switch (FEAT_TRAINS, SELF, switch_jsq6_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_VIHICLE_TRANSPORTER);
     return CB_RESULT_NO_TEXT;
@@ -98,5 +97,4 @@ item (FEAT_TRAINS, jsq6) {
     }
 }
 
-// End JSQ6
 

--- a/src/wagons/l70.pnml
+++ b/src/wagons/l70.pnml
@@ -1,4 +1,3 @@
-// Begin L70
 
 // Graphics
 
@@ -88,5 +87,4 @@ item (FEAT_TRAINS, l70) {
     }
 }
 
-// End B6
 

--- a/src/wagons/n5.pnml
+++ b/src/wagons/n5.pnml
@@ -1,4 +1,3 @@
-// Begin N5
 switch (FEAT_TRAINS, SELF, switch_n5_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_FLATCAR);
     return CB_RESULT_NO_TEXT;
@@ -193,5 +192,4 @@ item (FEAT_TRAINS, n5) {
     }
 }
 
-// End N60
 

--- a/src/wagons/n60.pnml
+++ b/src/wagons/n60.pnml
@@ -1,4 +1,3 @@
-//Begin N60
 switch (FEAT_TRAINS, SELF, switch_n60_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_FLATCAR);
     return CB_RESULT_NO_TEXT;
@@ -115,5 +114,4 @@ item (FEAT_TRAINS, n60) {
     }
 }
 
-// End N60
 

--- a/src/wagons/nx17.pnml
+++ b/src/wagons/nx17.pnml
@@ -1,4 +1,3 @@
-//Begin NX17
 switch (FEAT_TRAINS, SELF, switch_nx17_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_FLATCAR);
     return CB_RESULT_NO_TEXT;
@@ -412,7 +411,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_black_metal, cargo_count < 5) {
     0: switch_nx17_black_metal_not_empty;
     spriteset_nx17_black_metal_empty;
 }
-// end cargotype metal
 
 // start cargotype farm and engineer supplies
 random_switch (FEAT_TRAINS, SELF, switch_nx17_black_supplies_half) {
@@ -450,7 +448,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_black_supplies, cargo_count < 5) {
     0: switch_nx17_black_supplies_not_empty;
     spriteset_nx17_black_empty;
 }
-// end cargotype farm and engineer supplies
 
 // start cargotype vehicle
 random_switch (FEAT_TRAINS, SELF, switch_nx17_black_vehicle_half) {
@@ -484,7 +481,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_black_vehicle, cargo_count < 5) {
     0: switch_nx17_black_vehicle_not_empty;
     spriteset_nx17_black_empty;
 }
-// end cargotype vehicle
 
 // start cargotype black bulk (MNO2, COAL, COKE)
 
@@ -512,7 +508,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_black_open_container_black_bulk, cargo_co
     0: switch_nx17_black_open_container_black_bulk_not_empty;
     switch_nx17_black_open_container_black_bulk_empty;
 }
-// end cargotype black bulk (MNO2, COAL, COKE)
 
 // start cargotype brown bulk
 switch (FEAT_TRAINS, SELF, switch_nx17_black_open_container_brown_bulk_not_empty, cargo_count < 32) {
@@ -524,7 +519,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_black_open_container_brown_bulk, cargo_co
     0: switch_nx17_black_open_container_brown_bulk_not_empty;
     spriteset_nx17_black_open_container_cr_livery_empty;
 }
-// end cargotype brown bulk
 
 // start cargotype white bulk
 switch (FEAT_TRAINS, SELF, switch_nx17_black_open_container_white_bulk_not_empty, cargo_count < 32) {
@@ -536,7 +530,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_black_open_container_white_bulk, cargo_co
     0: switch_nx17_black_open_container_white_bulk_not_empty;
     spriteset_nx17_black_open_container_cr_livery_empty;
 }
-// end cargotype white bulk
 
 // start cargotype log
 switch (FEAT_TRAINS, SELF, switch_nx17_black_wood_not_empty, cargo_count < 32) {
@@ -548,7 +541,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_black_wood, cargo_count < 5) {
     0: switch_nx17_black_wood_not_empty;
     spriteset_nx17_black_wood_empty;
 }
-// end cargotype log
 
 switch (FEAT_TRAINS, SELF, switch_nx17_black_all_cargo, cargo_type_in_veh) {
 // the following list is shamelessly stolen from xUSSR
@@ -686,7 +678,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_black_all_cargo, cargo_type_in_veh) {
 
     switch_nx17_black;
 }
-// end alternative colour nx17_black
 
 // start alternative colour nx17_brown
 random_switch (FEAT_TRAINS, SELF, switch_nx17_brown_container_half) {
@@ -780,7 +771,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_brown_metal, cargo_count < 5) {
     0: switch_nx17_brown_metal_not_empty;
     spriteset_nx17_brown_metal_empty;
 }
-// end cargotype metal
 
 // start cargotype farm and engineer supplies
 random_switch (FEAT_TRAINS, SELF, switch_nx17_brown_supplies_half) {
@@ -818,7 +808,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_brown_supplies, cargo_count < 5) {
     0: switch_nx17_brown_supplies_not_empty;
     spriteset_nx17_brown_empty;
 }
-// end cargotype farm and engineer supplies
 
 // start cargotype vehicle
 random_switch (FEAT_TRAINS, SELF, switch_nx17_brown_vehicle_half) {
@@ -852,7 +841,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_brown_vehicle, cargo_count < 5) {
     0: switch_nx17_brown_vehicle_not_empty;
     spriteset_nx17_brown_empty;
 }
-// end cargotype vehicle
 
 // start cargotype black bulk (MNO2, COAL, COKE)
 
@@ -880,7 +868,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_brown_open_container_black_bulk, cargo_co
     0: switch_nx17_brown_open_container_black_bulk_not_empty;
     switch_nx17_brown_open_container_black_bulk_empty;
 }
-// end cargotype black bulk (MNO2, COAL, COKE)
 
 // start cargotype brown bulk
 switch (FEAT_TRAINS, SELF, switch_nx17_brown_open_container_brown_bulk_not_empty, cargo_count < 32) {
@@ -892,7 +879,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_brown_open_container_brown_bulk, cargo_co
     0: switch_nx17_brown_open_container_brown_bulk_not_empty;
     spriteset_nx17_brown_open_container_cr_livery_empty;
 }
-// end cargotype brown bulk
 
 // start cargotype white bulk
 switch (FEAT_TRAINS, SELF, switch_nx17_brown_open_container_white_bulk_not_empty, cargo_count < 32) {
@@ -904,7 +890,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_brown_open_container_white_bulk, cargo_co
     0: switch_nx17_brown_open_container_white_bulk_not_empty;
     spriteset_nx17_brown_open_container_cr_livery_empty;
 }
-// end cargotype white bulk
 
 // start cargotype log
 switch (FEAT_TRAINS, SELF, switch_nx17_brown_wood_not_empty, cargo_count < 32) {
@@ -916,7 +901,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_brown_wood, cargo_count < 5) {
     0: switch_nx17_brown_wood_not_empty;
     spriteset_nx17_brown_wood_empty;
 }
-// end cargotype log
 
 switch (FEAT_TRAINS, SELF, switch_nx17_brown_all_cargo, cargo_type_in_veh) {
 // the following list is shamelessly stolen from xUSSR
@@ -1055,7 +1039,6 @@ switch (FEAT_TRAINS, SELF, switch_nx17_brown_all_cargo, cargo_type_in_veh) {
     switch_nx17_brown;
 }
 
-// end alternative colour nx17_brown
 
 /* random_switch (FEAT_TRAINS, SELF, random_nx17_colour) {
     1: switch_nx17_black_all_cargo;
@@ -1168,5 +1151,4 @@ item (FEAT_TRAINS, nx17) {
     }
 }
 
-// End NX17
 

--- a/src/wagons/nx70a.pnml
+++ b/src/wagons/nx70a.pnml
@@ -1,4 +1,3 @@
-//Begin NX70A
 switch (FEAT_TRAINS, SELF, switch_nx70a_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_FLATCAR);
     return CB_RESULT_NO_TEXT;
@@ -259,7 +258,6 @@ switch (FEAT_TRAINS, SELF, switch_nx70a_black_metal, cargo_count < 5) {
     0: switch_nx70a_black_metal_not_empty;
     spriteset_nx70a_black_metal_empty;
 }
-// end cargotype metal
 
 // start cargotype farm and engineer supplies
 random_switch (FEAT_TRAINS, SELF, switch_nx70a_black_supplies_half) {
@@ -297,7 +295,6 @@ switch (FEAT_TRAINS, SELF, switch_nx70a_black_supplies, cargo_count < 5) {
     0: switch_nx70a_black_supplies_not_empty;
     spriteset_nx70a_black_empty;
 }
-// end cargotype farm and engineer supplies
 
 // start cargotype vehicle
 random_switch (FEAT_TRAINS, SELF, switch_nx70a_black_vehicle_half) {
@@ -331,7 +328,6 @@ switch (FEAT_TRAINS, SELF, switch_nx70a_black_vehicle, cargo_count < 5) {
     0: switch_nx70a_black_vehicle_not_empty;
     spriteset_nx70a_black_empty;
 }
-// end cargotype vehicle
 
 // start cargotype black bulk (MNO2, COAL, COKE)
 
@@ -359,7 +355,6 @@ switch (FEAT_TRAINS, SELF, switch_nx70a_black_open_container_black_bulk, cargo_c
     0: switch_nx70a_black_open_container_black_bulk_not_empty;
     switch_nx70a_black_open_container_black_bulk_empty;
 }
-// end cargotype black bulk (MNO2, COAL, COKE)
 
 // start cargotype brown bulk
 switch (FEAT_TRAINS, SELF, switch_nx70a_black_open_container_brown_bulk_not_empty, cargo_count < 32) {
@@ -371,7 +366,6 @@ switch (FEAT_TRAINS, SELF, switch_nx70a_black_open_container_brown_bulk, cargo_c
     0: switch_nx70a_black_open_container_brown_bulk_not_empty;
     spriteset_nx70a_black_open_container_cr_livery_empty;
 }
-// end cargotype brown bulk
 
 // start cargotype white bulk
 switch (FEAT_TRAINS, SELF, switch_nx70a_black_open_container_white_bulk_not_empty, cargo_count < 32) {
@@ -383,7 +377,6 @@ switch (FEAT_TRAINS, SELF, switch_nx70a_black_open_container_white_bulk, cargo_c
     0: switch_nx70a_black_open_container_white_bulk_not_empty;
     spriteset_nx70a_black_open_container_cr_livery_empty;
 }
-// end cargotype white bulk
 
 // start cargotype log
 switch (FEAT_TRAINS, SELF, switch_nx70a_black_wood_not_empty, cargo_count < 32) {
@@ -395,7 +388,6 @@ switch (FEAT_TRAINS, SELF, switch_nx70a_black_wood, cargo_count < 5) {
     0: switch_nx70a_black_wood_not_empty;
     spriteset_nx70a_black_wood_empty;
 }
-// end cargotype log
 
 switch (FEAT_TRAINS, SELF, switch_nx70a_black_all_cargo, cargo_type_in_veh) {
 // the following list is shamelessly stolen from xUSSR
@@ -533,7 +525,6 @@ switch (FEAT_TRAINS, SELF, switch_nx70a_black_all_cargo, cargo_type_in_veh) {
 
     switch_nx70a_black;
 }
-// end alternative colour nx70a_black
 
 
 random_switch (FEAT_TRAINS, SELF, random_nx70a_colour) {
@@ -627,5 +618,4 @@ item (FEAT_TRAINS, nx70a) {
     }
 }
 
-// End NX70A
 

--- a/src/wagons/p50.pnml
+++ b/src/wagons/p50.pnml
@@ -1,4 +1,3 @@
-// Begin P50
 switch (FEAT_TRAINS, SELF, switch_p50_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_BOXCAR);
     return CB_RESULT_NO_TEXT;
@@ -166,4 +165,3 @@ item (FEAT_TRAINS, p50) {
     }
 }
 
-// End P50

--- a/src/wagons/p60.pnml
+++ b/src/wagons/p60.pnml
@@ -1,4 +1,3 @@
-//Begin P60
 switch (FEAT_TRAINS, SELF, switch_p60_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_BOXCAR);
     return CB_RESULT_NO_TEXT;
@@ -126,5 +125,4 @@ item (FEAT_TRAINS, p60) {
     }
 }
 
-// End P60
 

--- a/src/wagons/p61.pnml
+++ b/src/wagons/p61.pnml
@@ -1,4 +1,3 @@
-//Begin P61
 switch (FEAT_TRAINS, SELF, switch_p61_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_BOXCAR);
     return CB_RESULT_NO_TEXT;
@@ -126,5 +125,4 @@ item (FEAT_TRAINS, p61) {
     }
 }
 
-// End P61
 

--- a/src/wagons/p62.pnml
+++ b/src/wagons/p62.pnml
@@ -1,4 +1,3 @@
-//Begin P62
 switch (FEAT_TRAINS, SELF, switch_p62_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_BOXCAR);
     return CB_RESULT_NO_TEXT;
@@ -190,5 +189,4 @@ item (FEAT_TRAINS, p62) {
     }
 }
 
-// End P62
 

--- a/src/wagons/p63.pnml
+++ b/src/wagons/p63.pnml
@@ -1,4 +1,3 @@
-//Begin P63
 switch (FEAT_TRAINS, SELF, switch_p63_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_BOXCAR);
     return CB_RESULT_NO_TEXT;
@@ -134,5 +133,4 @@ item (FEAT_TRAINS, p63) {
     }
 }
 
-// End P63
 

--- a/src/wagons/p65.pnml
+++ b/src/wagons/p65.pnml
@@ -1,4 +1,3 @@
-//Begin P65
 switch (FEAT_TRAINS, SELF, switch_p65_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_BOXCAR);
     return CB_RESULT_NO_TEXT;
@@ -107,4 +106,3 @@ item (FEAT_TRAINS, p65) {
     }
 }
 
-// End P65

--- a/src/wagons/p70.pnml
+++ b/src/wagons/p70.pnml
@@ -1,4 +1,3 @@
-//Begin P70
 switch (FEAT_TRAINS, SELF, switch_p70_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_BOXCAR);
     return CB_RESULT_NO_TEXT;
@@ -150,5 +149,4 @@ item (FEAT_TRAINS, p70) {
     }
 }
 
-// End P70
 

--- a/src/wagons/p80.pnml
+++ b/src/wagons/p80.pnml
@@ -1,4 +1,3 @@
-//Begin P80
 switch (FEAT_TRAINS, SELF, switch_p80_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_BOXCAR);
     return CB_RESULT_NO_TEXT;
@@ -113,4 +112,3 @@ item (FEAT_TRAINS, p80) {
     }
 }
 
-// End P80

--- a/src/wagons/pb.pnml
+++ b/src/wagons/pb.pnml
@@ -1,4 +1,3 @@
-//Begin PB
 switch (FEAT_TRAINS, SELF, switch_pb_name, getbits(extra_callback_info1, 0, 8) == 0x20? getbits(extra_callback_info1, 8, 8) : 0xFFFF) {
     0: return string(STR_BOXCAR);
     return CB_RESULT_NO_TEXT;
@@ -109,5 +108,4 @@ item (FEAT_TRAINS, pb) {
     }
 }
 
-// End PB
 


### PR DESCRIPTION
Those comments are unnecessary. Their only use case is when they're compiled into one single NML file and the reader can use them to determine where each file starts and ends. However GCC can output the start and end in the form of "#" comments and it can do the job better (i.e. readable by NMLC). So here is a PR to remove all of them.

Script used

```py
import glob
import re

# get all files recursively
files = glob.glob('**/*.pnml', recursive=True)

class RemoveHeader:
    def __init__(self, path: str):
        self.path = path

    def remove(self):
        with open(self.path, "r", encoding="utf-8-sig") as file:
            newfile = []
            for line in file:
                if re.match(r"//\s*?(begin|end)\s.*$", line.lower()):
                    line = ""
                newfile.append(line)
        with open(self.path, "w", encoding="utf-8") as file:
            file.writelines(newfile)

for file in files:
    rm = RemoveHeader(file)
    rm.remove()
```

Note that This PR might confilct with the previous PR that repaced vehicle ids.