### PR TITLE
Change: pass parameters to language strings

### DIFF
--- a/lang/english.lng
+++ b/lang/english.lng
@@ -1,4 +1,5 @@
 ﻿##grflangid 0x01
+##plural 0
 
 STR_GRF_NAME        :China Set: Trains {VERSION_STRING}
 STR_GRF_DESC        :The Train sector of the China Set of OpenTTD.
@@ -16,18 +17,11 @@ STR_PARAM_PURCHASE_COST_DESC :Adjust vehicle purchase costs. Default is 25%.
 STR_PARAM_RUNNING_COST       :Running costs
 STR_PARAM_RUNNING_COST_DESC  :Adjust vehicle running costs. Default is 25%.
 
-STR_PARAM_DIVIDE_16 :6.25%
-STR_PARAM_DIVIDE_8  :12.5%
-STR_PARAM_DIVIDE_4  :25%
-STR_PARAM_DIVIDE_2  :50%
-STR_PARAM_NORMAL    :100%
-STR_PARAM_TIMES_2   :200%
-STR_PARAM_TIMES_4   :400%
-STR_PARAM_TIMES_8   :800%
-STR_PARAM_TIMES_16  :1600%
+STR_PERCENTAGE      :{COMMA}%
 
 STR_PARAM_CARGO_DECAY       :Cargo Age Period
 STR_PARAM_CARGO_DECAY_DESC  :Adjust cargo age period of coaches and wagons. "Long" is "Standard" doubled, while "Very Long" is "Long" doubled. Even in "Standard" mode, cargo age period varies.
+
 STR_PARAM_STANDARD          :Standard
 STR_PARAM_LONG              :Long
 STR_PARAM_VERY_LONG         :Very Long
@@ -353,7 +347,7 @@ STR_FULL_NAME_DF4D           :{BLACK}Full Name: {GOLD}Dongfeng 4D Diesel Locomot
 STR_FULL_NAME_DF4D7000       :{BLACK}Full Name: {GOLD}Dongfeng 4D Diesel Locomotive 7000 Series
 STR_FULL_NAME_DF4DF          :{BLACK}Full Name: {GOLD}Dongfeng 4DF Diesel Locomotive
 STR_FULL_NAME_DF4E           :{BLACK}Full Name: {GOLD}Dongfeng 4E Diesel Locomotive
-STR_FULL_NAME_DF5KZ          :{BLACK}Full Name: {GOLD}Dongfeng 5 Diesel Locomotive 
+STR_FULL_NAME_DF5KZ          :{BLACK}Full Name: {GOLD}Dongfeng 5 Diesel Locomotive
 STR_FULL_NAME_DF5            :{BLACK}Full Name: {GOLD}Dongfeng 5 Diesel Locomotive 1000 Series
 STR_FULL_NAME_DF7G           :{BLACK}Full Name: {GOLD}Dongfeng 7G Diesel Locomotive
 STR_FULL_NAME_DF7G5000       :{BLACK}Full Name: {GOLD}Dongfeng 7G Diesel Locomotive 5000 Series
@@ -433,7 +427,7 @@ STR_S25BLD_SERIES               :Type S25B Series Coaches (Low-Door)
 STR_S25BHD_SERIES               :Type S25B Series Coaches (High-Door)
 STR_25G_SERIES                  :Type 25G Series Coaches
 STR_25Z_SERIES                  :Type 25Z Series Coaches
-STR_S25Z_SERIES                 :Type S25Z Series Coaches 
+STR_S25Z_SERIES                 :Type S25Z Series Coaches
 STR_25K_SERIES                  :Type 25K Series Coaches
 STR_S25KLD_SERIES               :Type S25K Series Coaches (Low-Door)
 STR_S25KHD_SERIES               :Type S25K Series Coaches (High-Door)
@@ -453,7 +447,7 @@ STR_VIHICLE_TRANSPORTER         :Vihicle Transporter
 
 
 
-STR_US_IMPORT                :Imported from United States
+STR_US_IMPORT                :Imported from the United States
 STR_FR_IMPORT                :Imported from France
 STR_HU_IMPORT                :Imported from Hungary
 
@@ -570,10 +564,10 @@ STR_HXD3D_NICKNAME                  :{BLACK}Nickname: {GOLD}Tomato
 STR_NDJ3_NICKNAME                   :{BLACK}Nickname: {WHITE}White Pig
 STR_CR200J_NICKNAME                 :{BLACK}Nickname: {GREEN}"Hulk" {GOLD}(Official), {GREEN}"Trash Bin" {GOLD}(Folk)
 STR_CR200JC_NICKNAME                :{BLACK}Nickname: {GREEN}"AD Bin" {GOLD}(Folk)
-STR_CRH1A_NICKNAME                  :{BLACK}Nickname: {GOLD}Metro 
-STR_CRH1B_NICKNAME                  :{BLACK}Nickname: {GOLD}Long Metro 
-STR_CRH1E_NICKNAME                  :{BLACK}Nickname: {GOLD}Sleeping Metro 
-STR_CRH1AA_NICKNAME                 :{BLACK}Nickname: {GOLD}Cute Metro 
+STR_CRH1A_NICKNAME                  :{BLACK}Nickname: {GOLD}Metro
+STR_CRH1B_NICKNAME                  :{BLACK}Nickname: {GOLD}Long Metro
+STR_CRH1E_NICKNAME                  :{BLACK}Nickname: {GOLD}Sleeping Metro
+STR_CRH1AA_NICKNAME                 :{BLACK}Nickname: {GOLD}Cute Metro
 STR_CRH2A_NICKNAME                  :{BLACK}Nickname: {GOLD}Hairtail
 STR_CRH2B_NICKNAME                  :{BLACK}Nickname: {GOLD}Long Hairtail
 STR_CRH2C_NICKNAME                  :{BLACK}Nickname: {GOLD}Crazy Hairtail
@@ -596,25 +590,21 @@ STR_ALIASNAME_DF                    :{BLACK}Alias Name: {GOLD}Great Loong
 STR_ALIASNME_SS1                    :{BLACK}Alias Name: {GOLD}6Y1
 STR_ALIASNAME_FXD1B                 :{BLACK}Alias Name: {GOLD}HXD1F (Hexie/Harmony 1F Electric Locomotive)
 
-STR_RELIABILITY_32                  :{BLACK}Reliability decay speed: {GOLD}32
-STR_RELIABILITY_24                  :{BLACK}Reliability decay speed: {GOLD}24
-STR_RELIABILITY_20                  :{BLACK}Reliability decay speed: {GOLD}20
-STR_RELIABILITY_16                  :{BLACK}Reliability decay speed: {GOLD}16
-STR_RELIABILITY_15                  :{BLACK}Reliability decay speed: {GOLD}15
-STR_RELIABILITY_14                  :{BLACK}Reliability decay speed: {GOLD}14
-STR_RELIABILITY_12                  :{BLACK}Reliability decay speed: {GOLD}12
-STR_RELIABILITY_10                  :{BLACK}Reliability decay speed: {GOLD}10
-STR_RELIABILITY_8                   :{BLACK}Reliability decay speed: {GOLD}8
-STR_RELIABILITY_6                   :{BLACK}Reliability decay speed: {GOLD}6
-STR_RELIABILITY_5                   :{BLACK}Reliability decay speed: {GOLD}5
-STR_RELIABILITY_3                   :{BLACK}Reliability decay speed: {GOLD}3
-
+STR_RELIABILITY                     :{BLACK}Reliability decay speed: {PUSH_COLOUR}{GOLD}{COMMA}{POP_COLOUR}
+# TODO
 STR_310_KMH             : - Max Speed 310 km/h
 STR_350_KMH             : - Max Speed 350 km/h, Running Costs Increase
 STR_380_KMH             : - Max Speed 380 km/h, Running Costs Greatly Increase
 
+STR_MAX_SPEED           : - Max Speed {VELOCITY}
+STR_MAX_SPEED_INCREASED : - Max Speed {VELOCITY} (Increasing running costs)
+STR_MAX_SPEED_DECREASED : - Max Speed {VELOCITY} (Decreasing running costs)
+
 STR_350_AVAILABLE       :Refittable to Max Speed 350 km/h (Increasing running costs)
 STR_350_380_AVAILABLE   :Refittable to Max Speed 350 or 380 km/h (Increasing running costs)
+
+STR_SPEED_AVAILABLE_1   :Refittable to Max Speed {VELOCITY} (Increasing running costs)
+STR_SPEED_AVAILABLE_2   :Refittable to Max Speed {VELOCITY} or {VELOCITY} (Increasing running costs)
 
 STR_ORIGINAL            : - Original Livery
 STR_REVERSE             : └ the Reverse of the Livery Above
@@ -702,38 +692,14 @@ STR_XIAOYONG            : - Xiaoshan/Hangzhou-Ningbo Livery
 
 STR_JINLUN_25DT         :Coaches use for DMU {BLUE}"JIN{WHITE}LUN"
 
-STR_COMFORT             :{BLACK}Comfort: {GOLD}{COMMA}
+STR_COMFORT             :{BLACK}Comfort: {PUSH_COLOUR}{GOLD}{COMMA}{POP_COLOUR}
+STR_COMFORT_PREF        :{BLACK}Comfort: {PUSH_COLOUR}{GOLD}{COMMA}{POP_COLOUR}{STRING}
+STR_COMFORT_CAFE        :, but at least {COMMA} in operation due to its restaurant identity
+STR_COMFORT_AC          :, but at least {COMMA} in operation due to the presence of air conditioner
 
-STR_COMFORT_108         :{BLACK}Comfort: {GOLD}108
-STR_COMFORT_144         :{BLACK}Comfort: {GOLD}144
-STR_COMFORT_160         :{BLACK}Comfort: {GOLD}160
-STR_COMFORT_192         :{BLACK}Comfort: {GOLD}192
-STR_COMFORT_256         :{BLACK}Comfort: {GOLD}256
-STR_COMFORT_288         :{BLACK}Comfort: {GOLD}288
-STR_COMFORT_320         :{BLACK}Comfort: {GOLD}320
-STR_COMFORT_384         :{BLACK}Comfort: {GOLD}384
-
-STR_COMFORT_144_CAFE    :{BLACK}Comfort: {GOLD}144 {BLACK}, but at least 180 in operation due to its restaurant identity
-STR_COMFORT_160_CAFE    :{BLACK}Comfort: {GOLD}160 {BLACK}, but at least 200 in operation due to its restaurant identity
-STR_COMFORT_192_CAFE    :{BLACK}Comfort: {GOLD}192 {BLACK}, but at least 240 in operation due to its restaurant identity
-STR_COMFORT_384_AC      :{BLACK}Comfort: {GOLD}384 {BLACK}, but at least 480 in operation due to the presence of air conditioner
-
-STR_COMFORT_240         :{BLACK}Comfort: {GOLD}240
-STR_COMFORT_400         :{BLACK}Comfort: {GOLD}400
-STR_COMFORT_480         :{BLACK}Comfort: {GOLD}480
-STR_COMFORT_640         :{BLACK}Comfort: {GOLD}640
-STR_COMFORT_720         :{BLACK}Comfort: {GOLD}720
-STR_COMFORT_800         :{BLACK}Comfort: {GOLD}800
-
-STR_COMFORT_240_CAFE    :{BLACK}Comfort: {GOLD}240 {BLACK}, but at least 300 in operation due to its restaurant identity
-
-STR_DECAY_185           :{BLACK}Cargo Age Period Factor: {GOLD}185
-STR_DECAY_200           :{BLACK}Cargo Age Period Factor: {GOLD}200
-STR_DECAY_400           :{BLACK}Cargo Age Period Factor: {GOLD}400
-STR_DECAY_800           :{BLACK}Cargo Age Period Factor: {GOLD}800
-STR_DECAY_1600          :{BLACK}Cargo Age Period Factor: {GOLD}1600
-STR_DECAY_BOXCAR        :{BLACK}Cargo Age Period Factor: {GOLD}185, Passengers 80, Livestock 560
-STR_DECAY_BOXCAR_NOPASS :{BLACK}Cargo Age Period Factor: {GOLD}185, Livestock 560, Unrefittable to Passengers
+STR_DECAY               :{BLACK}Cargo Age Period Factor: {PUSH_COLOUR}{GOLD}{COMMA}{POP_COLOUR}
+STR_DECAY_BOXCAR        :{BLACK}Cargo Age Period Factor: {PUSH_COLOUR}{GOLD}{COMMA}, Passengers {COMMA}, Livestock {COMMA}{POP_COLOUR}
+STR_DECAY_BOXCAR_NOPAX  :{BLACK}Cargo Age Period Factor: {PUSH_COLOUR}{GOLD}{COMMA}, Livestock {COMMA}, Unrefittable to Passengers{POP_COLOUR}
 
 STR_CAFE_EFFECT                     :{BLACK}Cafe Effect: {GOLD}Attaching Restaurant Car Halves Running Costs of Non-Commuter Passenger Cars except Restaurant Cars, and Increases Cargo Age Period by 1/4
 STR_AIR_CONDITIONER_EFFECT          :{BLACK}Air Conditioner Effect: {GOLD}Attaching Air Conditioner Generator Car Increases Cargo Age Period of Most Passenger Cars Hauled by Locomotives without Electricity Supply
@@ -825,7 +791,4 @@ STR_ELECTRICITY_SUPPLY_NO           :{BLACK}Electricity Supply for cars: {RED}NO
 STR_TOO_SHORT                       :TOO SHORT!
 STR_ONLY_TWO_SECTIONS               :This locomotive must be in a consist of two sections to run.
 STR_MUST_BE_4_8_12_16_CARS          :This MU must be in a consist of 4, 8, 12 or 16 cars to run.
-STR_MUST_BE_5_TO_17_CARS            :This MU must be in a consist of 5 to 17 cars to run.
-STR_MUST_BE_2_TO_16_CARS            :This MU must be in a consist of 2 to 16 cars to run.
-STR_MUST_BE_4_TO_24_CARS            :This MU must be in a consist of 4 to 24 cars to run.
-STR_MUST_BE_8_TO_24_CARS            :This MU must be in a consist of 8 to 24 cars to run.
+STR_MUST_BE_RANGE_CARS              :This MU must be in a consist of {COMMA} to {COMMA} car{P "" s} to run.

--- a/src/25-electric/6y2.pnml
+++ b/src/25-electric/6y2.pnml
@@ -82,7 +82,7 @@ item (FEAT_TRAINS, _6y2) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FR_IMPORT), string(STR_ELECTRICITY_SUPPLY_NO),  string(STR_6Y2_LIVERY_AVAILABILITY),string(STR_RELIABILITY_12));
+        additional_text:                string(STR_DESC_4, string(STR_FR_IMPORT), string(STR_ELECTRICITY_SUPPLY_NO),  string(STR_6Y2_LIVERY_AVAILABILITY),string(STR_RELIABILITY, 12));
         cargo_subtype_text:             switch_6y2_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/25-electric/hxd1.pnml
+++ b/src/25-electric/hxd1.pnml
@@ -66,7 +66,7 @@ item (FEAT_TRAINS, hxd1) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD1), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXD1_NICKNAME), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD1), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXD1_NICKNAME), string(STR_RELIABILITY, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd1_graphics;

--- a/src/25-electric/hxd11000.pnml
+++ b/src/25-electric/hxd11000.pnml
@@ -72,7 +72,7 @@ item (FEAT_TRAINS, hxd11000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD11000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD11000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd11000_graphics;

--- a/src/25-electric/hxd1b.pnml
+++ b/src/25-electric/hxd1b.pnml
@@ -68,7 +68,7 @@ item (FEAT_TRAINS, hxd1b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD1B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXD1B_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD1B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXD1B_NICKNAME), string(STR_RELIABILITY, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd1b_graphics;

--- a/src/25-electric/hxd1d.pnml
+++ b/src/25-electric/hxd1d.pnml
@@ -68,7 +68,7 @@ item (FEAT_TRAINS, hxd1d) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD1D), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_HXD1D_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD1D), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_HXD1D_NICKNAME), string(STR_RELIABILITY, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd1d_graphics;

--- a/src/25-electric/hxd1f.pnml
+++ b/src/25-electric/hxd1f.pnml
@@ -99,7 +99,7 @@ item (FEAT_TRAINS, hxd1f) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_FXD1B), string(STR_ALIASNAME_FXD1B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_FXD1B), string(STR_ALIASNAME_FXD1B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY, 8));
         cargo_subtype_text:             switch_hxd1f_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/25-electric/hxd3c.pnml
+++ b/src/25-electric/hxd3c.pnml
@@ -62,7 +62,7 @@ item (FEAT_TRAINS, hxd3c) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD3C), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_HXD3C_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD3C), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_HXD3C_NICKNAME), string(STR_RELIABILITY, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd3c_graphics;

--- a/src/25-electric/hxd3d.pnml
+++ b/src/25-electric/hxd3d.pnml
@@ -68,7 +68,7 @@ item (FEAT_TRAINS, hxd3d) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD3D), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_HXD3D_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD3D), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_HXD3D_NICKNAME), string(STR_RELIABILITY, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd3d_graphics;

--- a/src/25-electric/ss1.pnml
+++ b/src/25-electric/ss1.pnml
@@ -77,7 +77,7 @@ item (FEAT_TRAINS, ss1) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS1), string(STR_ALIASNME_SS1), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS1_NICKNAME), string(STR_RELIABILITY_20));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS1), string(STR_ALIASNME_SS1), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS1_NICKNAME), string(STR_RELIABILITY, 20));
         cargo_subtype_text:             switch_ss1_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/25-electric/ss3.pnml
+++ b/src/25-electric/ss3.pnml
@@ -63,7 +63,7 @@ item (FEAT_TRAINS, ss3) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS3), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS3_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS3), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS3_NICKNAME), string(STR_RELIABILITY, 10));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss3_graphics;

--- a/src/25-electric/ss3b.pnml
+++ b/src/25-electric/ss3b.pnml
@@ -67,7 +67,7 @@ item (FEAT_TRAINS, ss3b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS3B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS3B_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS3B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS3B_NICKNAME), string(STR_RELIABILITY, 10));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss3b_graphics;

--- a/src/25-electric/ss4.pnml
+++ b/src/25-electric/ss4.pnml
@@ -67,7 +67,7 @@ item (FEAT_TRAINS, ss4) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS4), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS4_NICKNAME), string(STR_RELIABILITY_20));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS4), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS4_NICKNAME), string(STR_RELIABILITY, 20));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss4_graphics;

--- a/src/25-electric/ss4g.pnml
+++ b/src/25-electric/ss4g.pnml
@@ -72,7 +72,7 @@ item (FEAT_TRAINS, ss4g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS4G), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS4G_NICKNAME), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS4G), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS4G_NICKNAME), string(STR_RELIABILITY, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss4g_graphics;

--- a/src/25-electric/ss5.pnml
+++ b/src/25-electric/ss5.pnml
@@ -63,7 +63,7 @@ item (FEAT_TRAINS, ss5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS5_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS5_NICKNAME), string(STR_RELIABILITY, 16));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss5_graphics;

--- a/src/25-electric/ss6.pnml
+++ b/src/25-electric/ss6.pnml
@@ -63,7 +63,7 @@ item (FEAT_TRAINS, ss6) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS6), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS6_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS6), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS6_NICKNAME), string(STR_RELIABILITY, 10));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss6_graphics;

--- a/src/25-electric/ss6b.pnml
+++ b/src/25-electric/ss6b.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, ss6b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS6B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS6B_NICKNAME), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS6B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS6B_NICKNAME), string(STR_RELIABILITY, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss6b_graphics;

--- a/src/25-electric/ss7.pnml
+++ b/src/25-electric/ss7.pnml
@@ -64,7 +64,7 @@ item (FEAT_TRAINS, ss7) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS7_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS7_NICKNAME), string(STR_RELIABILITY, 16));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss7_graphics;

--- a/src/25-electric/ss7b.pnml
+++ b/src/25-electric/ss7b.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, ss7b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS7B_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS7B_NICKNAME), string(STR_RELIABILITY, 16));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss7b_graphics;

--- a/src/25-electric/ss7c.pnml
+++ b/src/25-electric/ss7c.pnml
@@ -83,7 +83,7 @@ item (FEAT_TRAINS, ss7c) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_SS7C), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS7C_LIVERY_AVAILABILITY), string(STR_SS7C_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_SS7C), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS7C_LIVERY_AVAILABILITY), string(STR_SS7C_NICKNAME), string(STR_RELIABILITY, 10));
         cargo_subtype_text:             switch_ss7c_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/25-electric/ss7d.pnml
+++ b/src/25-electric/ss7d.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, ss7d) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7D), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS7D_NICKNAME), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7D), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS7D_NICKNAME), string(STR_RELIABILITY, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss7d_graphics;

--- a/src/25-electric/ss7e.pnml
+++ b/src/25-electric/ss7e.pnml
@@ -63,7 +63,7 @@ item (FEAT_TRAINS, ss7e) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7E), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS7E_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7E), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS7E_NICKNAME), string(STR_RELIABILITY, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss7e_graphics;

--- a/src/25-electric/ss8.pnml
+++ b/src/25-electric/ss8.pnml
@@ -63,7 +63,7 @@ item (FEAT_TRAINS, ss8) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS8), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS8_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS8), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS8_NICKNAME), string(STR_RELIABILITY, 10));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss8_graphics;

--- a/src/25-electric/ss9.pnml
+++ b/src/25-electric/ss9.pnml
@@ -63,7 +63,7 @@ item (FEAT_TRAINS, ss9) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS9), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS9_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS9), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS9_NICKNAME), string(STR_RELIABILITY, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss9_graphics;

--- a/src/25-electric/ss9g.pnml
+++ b/src/25-electric/ss9g.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, ss9g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS9G), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS9G_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS9G), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS9G_NICKNAME), string(STR_RELIABILITY, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss9g_graphics;

--- a/src/25-emu/cr200ja.pnml
+++ b/src/25-emu/cr200ja.pnml
@@ -347,7 +347,7 @@ item (FEAT_TRAINS, cr200ja) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR200J_NICKNAME), string(STR_RELIABILITY_20), string(STR_CR200J_CONSIST));
+        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR200J_NICKNAME), string(STR_RELIABILITY, 20), string(STR_CR200J_CONSIST));
         can_attach_wagon:               cr200jawagon;
         start_stop:                     mu4car;
         // Graphics

--- a/src/25-emu/cr200jal.pnml
+++ b/src/25-emu/cr200jal.pnml
@@ -250,7 +250,7 @@ item (FEAT_TRAINS, cr200jal) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CR200J_CAN_ATTACH_WAGON), string(STR_CR200J_NICKNAME), string(STR_RELIABILITY_20), string(STR_CR200JL_CONSIST));
+        additional_text:                string(STR_DESC_4, string(STR_CR200J_CAN_ATTACH_WAGON), string(STR_CR200J_NICKNAME), string(STR_RELIABILITY, 20), string(STR_CR200JL_CONSIST));
         can_attach_wagon:               cr200jalwagon;
         start_stop:                     mu8car;
         // Graphics

--- a/src/25-emu/cr200jb.pnml
+++ b/src/25-emu/cr200jb.pnml
@@ -307,7 +307,7 @@ item (FEAT_TRAINS, cr200jb) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR200J_NICKNAME), string(STR_RELIABILITY_12), string(STR_CR200J_CONSIST));
+        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR200J_NICKNAME), string(STR_RELIABILITY, 12), string(STR_CR200J_CONSIST));
         can_attach_wagon:               cr200jbwagon;
         start_stop:                     mu4car;
         // Graphics

--- a/src/25-emu/cr200jc.pnml
+++ b/src/25-emu/cr200jc.pnml
@@ -305,7 +305,7 @@ item (FEAT_TRAINS, cr200jc) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR200JC_NICKNAME), string(STR_RELIABILITY_8), string(STR_CR200J_CONSIST));
+        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR200JC_NICKNAME), string(STR_RELIABILITY, 8), string(STR_CR200J_CONSIST));
         can_attach_wagon:               cr200jcwagon;
         start_stop:                     switch_cr200jc_start_stop;
 

--- a/src/25-emu/cr200jcl.pnml
+++ b/src/25-emu/cr200jcl.pnml
@@ -179,7 +179,7 @@ item (FEAT_TRAINS, cr200jcl) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CR200J_CAN_ATTACH_WAGON), string(STR_CR200JC_NICKNAME), string(STR_RELIABILITY_8), string(STR_CR200JL_CONSIST));
+        additional_text:                string(STR_DESC_4, string(STR_CR200J_CAN_ATTACH_WAGON), string(STR_CR200JC_NICKNAME), string(STR_RELIABILITY, 8), string(STR_CR200JL_CONSIST));
         can_attach_wagon:               cr200jclwagon;
         start_stop:                     switch_cr200jcl_start_stop;
 

--- a/src/25-emu/cr300af.pnml
+++ b/src/25-emu/cr300af.pnml
@@ -273,7 +273,7 @@ item (FEAT_TRAINS, cr300af) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR300AF_NICKNAME), string(STR_CR300_CONSIST), string(STR_RELIABILITY_5), string(STR_CR300_HEAD_SEAT));
+        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR300AF_NICKNAME), string(STR_CR300_CONSIST), string(STR_RELIABILITY, 5), string(STR_CR300_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
 

--- a/src/25-emu/cr300bf.pnml
+++ b/src/25-emu/cr300bf.pnml
@@ -352,7 +352,7 @@ item (FEAT_TRAINS, cr300bf) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR300BF_NICKNAME), string(STR_CR300_CONSIST), string(STR_RELIABILITY_5), string(STR_CR300_HEAD_SEAT));
+        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR300BF_NICKNAME), string(STR_CR300_CONSIST), string(STR_RELIABILITY, 5), string(STR_CR300_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
 

--- a/src/25-emu/cr400af.pnml
+++ b/src/25-emu/cr400af.pnml
@@ -664,7 +664,7 @@ item (FEAT_TRAINS, cr400af) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400AF_NICKNAME), string(STR_RELIABILITY_5), string(STR_CR400_CONSIST), string(STR_CR400_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400AF_NICKNAME), string(STR_RELIABILITY, 5), string(STR_CR400_CONSIST), string(STR_CR400_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/cr400afab.pnml
+++ b/src/25-emu/cr400afab.pnml
@@ -279,7 +279,7 @@ item (FEAT_TRAINS, cr400afab) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400AF_NICKNAME), string(STR_RELIABILITY_5), string(STR_CR400_AB_CONSIST), string(STR_CR400_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400AF_NICKNAME), string(STR_RELIABILITY, 5), string(STR_CR400_AB_CONSIST), string(STR_CR400_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/cr400afabz.pnml
+++ b/src/25-emu/cr400afabz.pnml
@@ -326,7 +326,7 @@ item (FEAT_TRAINS, cr400afabz) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), /* string(STR_CR400AFZ_NICKNAME),  */string(STR_RELIABILITY_3), string(STR_CR400_AB_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), /* string(STR_CR400AFZ_NICKNAME),  */string(STR_RELIABILITY, 3), string(STR_CR400_AB_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/cr400afz.pnml
+++ b/src/25-emu/cr400afz.pnml
@@ -351,7 +351,7 @@ item (FEAT_TRAINS, cr400afz) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON),/*  string(STR_CR400AFZ_NICKNAME), */ string(STR_RELIABILITY_3), string(STR_CR400_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON),/*  string(STR_CR400AFZ_NICKNAME), */ string(STR_RELIABILITY, 3), string(STR_CR400_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/cr400bf.pnml
+++ b/src/25-emu/cr400bf.pnml
@@ -279,7 +279,7 @@ item (FEAT_TRAINS, cr400bf) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400BF_NICKNAME), string(STR_RELIABILITY_5), string(STR_CR400_CONSIST), string(STR_CR400_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400BF_NICKNAME), string(STR_RELIABILITY, 5), string(STR_CR400_CONSIST), string(STR_CR400_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/cr400bfab.pnml
+++ b/src/25-emu/cr400bfab.pnml
@@ -239,7 +239,7 @@ item (FEAT_TRAINS, cr400bfab) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400BF_NICKNAME), string(STR_RELIABILITY_5), string(STR_CR400_AB_CONSIST), string(STR_CR400_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400BF_NICKNAME), string(STR_RELIABILITY, 5), string(STR_CR400_AB_CONSIST), string(STR_CR400_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/crh1a.pnml
+++ b/src/25-emu/crh1a.pnml
@@ -274,7 +274,7 @@ item (FEAT_TRAINS, crh1a) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH1A_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH1A_CONSIST), string(STR_CRH1A_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH1A_NICKNAME), string(STR_RELIABILITY, 12), string(STR_CRH1A_CONSIST), string(STR_CRH1A_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/crh1aa.pnml
+++ b/src/25-emu/crh1aa.pnml
@@ -252,7 +252,7 @@ item (FEAT_TRAINS, crh1aa) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH1AA_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH1AA_CONSIST), string(STR_CRH1AA_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH1AA_NICKNAME), string(STR_RELIABILITY, 12), string(STR_CRH1AA_CONSIST), string(STR_CRH1AA_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/crh1b.pnml
+++ b/src/25-emu/crh1b.pnml
@@ -201,7 +201,7 @@ item (FEAT_TRAINS, crh1b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH1B_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH1B_CONSIST), string(STR_CRH1B_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH1B_NICKNAME), string(STR_RELIABILITY, 12), string(STR_CRH1B_CONSIST), string(STR_CRH1B_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/crh1e.pnml
+++ b/src/25-emu/crh1e.pnml
@@ -234,7 +234,7 @@ item (FEAT_TRAINS, crh1e) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_SLEEPER_CAN_ATTACH_WAGON), string(STR_CRH1E_NICKNAME), string(STR_RELIABILITY_8), string(STR_CRH1E_CONSIST), string(STR_CRH1E_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_SLEEPER_CAN_ATTACH_WAGON), string(STR_CRH1E_NICKNAME), string(STR_RELIABILITY, 8), string(STR_CRH1E_CONSIST), string(STR_CRH1E_HEAD_SEAT));
         can_attach_wagon:               crhsleeperonly;
         start_stop:                     mu4car;
         

--- a/src/25-emu/crh2a.pnml
+++ b/src/25-emu/crh2a.pnml
@@ -383,7 +383,7 @@ item (FEAT_TRAINS, crh2a) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2A_NICKNAME), string(STR_RELIABILITY_20), string(STR_CRH2A_CONSIST), string(STR_CRH2A_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2A_NICKNAME), string(STR_RELIABILITY, 20), string(STR_CRH2A_CONSIST), string(STR_CRH2A_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/crh2b.pnml
+++ b/src/25-emu/crh2b.pnml
@@ -270,7 +270,7 @@ item (FEAT_TRAINS, crh2b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2B_NICKNAME), string(STR_RELIABILITY_20), string(STR_CRH2B_CONSIST), string(STR_CRH2B_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2B_NICKNAME), string(STR_RELIABILITY, 20), string(STR_CRH2B_CONSIST), string(STR_CRH2B_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
 

--- a/src/25-emu/crh2c.pnml
+++ b/src/25-emu/crh2c.pnml
@@ -278,6 +278,11 @@ switch (FEAT_TRAINS, SELF, switch_crh2c_wagon_traction, vehicle_is_potentially_p
     return 0;
 }
 
+switch (FEAT_TRAINS, SELF, switch_crh2c_additional_text, [
+    STORE_TEMP(350, 0x100)
+]) {
+    string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2C_NICKNAME), string(STR_RELIABILITY, 15), string(STR_CRH2C_CONSIST), string(STR_CRH2C_HEAD_SEAT), string(STR_SPEED_AVAILABLE_1));
+}
 
 item (FEAT_TRAINS, crh2c) {
     property {
@@ -320,7 +325,7 @@ item (FEAT_TRAINS, crh2c) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2C_NICKNAME), string(STR_RELIABILITY_15), string(STR_CRH2C_CONSIST), string(STR_CRH2C_HEAD_SEAT), string(STR_350_AVAILABLE));
+        additional_text:                switch_crh2c_additional_text;
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         cargo_subtype_text:             switch_crh_c_cargo_subtype;

--- a/src/25-emu/crh2e.pnml
+++ b/src/25-emu/crh2e.pnml
@@ -314,7 +314,7 @@ item (FEAT_TRAINS, crh2e) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_SLEEPER_CAN_ATTACH_WAGON), string(STR_CRH2E_NICKNAME), string(STR_RELIABILITY_20), string(STR_CRH2E_CONSIST), string(STR_CRH2E_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_SLEEPER_CAN_ATTACH_WAGON), string(STR_CRH2E_NICKNAME), string(STR_RELIABILITY, 20), string(STR_CRH2E_CONSIST), string(STR_CRH2E_HEAD_SEAT));
         can_attach_wagon:               crhsleeperonly;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/crh2els.pnml
+++ b/src/25-emu/crh2els.pnml
@@ -204,7 +204,7 @@ item (FEAT_TRAINS, crh2els) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_LSLEEPER_CAN_ATTACH_WAGON), string(STR_CRH2G_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH2E_CONSIST), string(STR_CRH2ELS_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_LSLEEPER_CAN_ATTACH_WAGON), string(STR_CRH2G_NICKNAME), string(STR_RELIABILITY, 12), string(STR_CRH2E_CONSIST), string(STR_CRH2ELS_HEAD_SEAT));
         can_attach_wagon:               crh_wagons_longitudinal_sleeper;
         start_stop:                     mu4car;
         // Graphics

--- a/src/25-emu/crh2g.pnml
+++ b/src/25-emu/crh2g.pnml
@@ -320,7 +320,7 @@ item (FEAT_TRAINS, crh2g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2G_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH2G_CONSIST), string(STR_CRH2G_HEAD_SEAT));
+        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2G_NICKNAME), string(STR_RELIABILITY, 12), string(STR_CRH2G_CONSIST), string(STR_CRH2G_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4car;
         // Graphics

--- a/src/25-emu/crh380a.pnml
+++ b/src/25-emu/crh380a.pnml
@@ -313,6 +313,11 @@ switch (FEAT_TRAINS, SELF, switch_crh380a_wagon_traction, vehicle_is_potentially
     return 0;
 }
 
+switch (FEAT_TRAINS, SELF, switch_crh380a_additional_text, [
+    STORE_TEMP(350 | 380 << 16, 0x100)
+]) {
+    return string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380A_NICKNAME), string(STR_RELIABILITY, 12), string(STR_CRH380A_CONSIST), string(STR_CRH380A_HEAD_SEAT), string(STR_SPEED_AVAILABLE_2));
+}
 
 item (FEAT_TRAINS, crh380a) {
     property {
@@ -351,11 +356,11 @@ item (FEAT_TRAINS, crh380a) {
         running_cost_factor:            56;
         reliability_decay:              12;
         bitmask_vehicle_info:           bitmask(2);
-        
+
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380A_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH380A_CONSIST), string(STR_CRH380A_HEAD_SEAT), string(STR_350_380_AVAILABLE));
+        additional_text:                switch_crh380a_additional_text;
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         cargo_subtype_text:             switch_crh380_cargo_subtype;

--- a/src/25-emu/crh380al.pnml
+++ b/src/25-emu/crh380al.pnml
@@ -200,6 +200,11 @@ switch (FEAT_TRAINS, SELF, switch_crh380al_wagon_traction, vehicle_is_potentiall
     return 0;
 }
 
+switch (FEAT_TRAINS, SELF, switch_crh380al_additional_text, [
+    STORE_TEMP(350 | 380 << 16, 0x100)
+]) {
+    return string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380A_NICKNAME), string(STR_RELIABILITY, 12), string(STR_CRH380AL_CONSIST), string(STR_CRH380A_HEAD_SEAT), string(STR_SPEED_AVAILABLE_2));
+}
 
 item (FEAT_TRAINS, crh380al) {
     property {
@@ -242,7 +247,7 @@ item (FEAT_TRAINS, crh380al) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380A_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH380AL_CONSIST), string(STR_CRH380A_HEAD_SEAT), string(STR_350_380_AVAILABLE));
+        additional_text:                switch_crh380al_additional_text;
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         cargo_subtype_text:             switch_crh380_cargo_subtype;

--- a/src/25-emu/crh380b.pnml
+++ b/src/25-emu/crh380b.pnml
@@ -154,6 +154,11 @@ switch (FEAT_TRAINS, SELF, switch_crh380b_wagon_traction, vehicle_is_potentially
     return 0;
 }
 
+switch (FEAT_TRAINS, SELF, switch_crh380b_additioanl_text, [
+    STORE_TEMP(350 | 380 << 16, 0x100)
+]){
+    return string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380B_NICKNAME), string(STR_RELIABILITY, 5), string(STR_CRH380B_CONSIST), string(STR_CRH380B_HEAD_SEAT), string(STR_SPEED_AVAILABLE_2));
+}
 
 item (FEAT_TRAINS, crh380b) {
     property {
@@ -195,7 +200,7 @@ item (FEAT_TRAINS, crh380b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380B_NICKNAME), string(STR_RELIABILITY_5), string(STR_CRH380B_CONSIST), string(STR_CRH380B_HEAD_SEAT), string(STR_350_380_AVAILABLE));
+        additional_text:                switch_crh380b_additioanl_text;
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh380_cargo_subtype;

--- a/src/25-emu/crh380cl.pnml
+++ b/src/25-emu/crh380cl.pnml
@@ -149,6 +149,11 @@ switch (FEAT_TRAINS, SELF, switch_crh380cl_wagon_traction, vehicle_is_potentiall
     return 0;
 }
 
+switch (FEAT_TRAINS, SELF, switch_crh380cl_additional_text, [
+    STORE_TEMP(350 | 380 << 16, 0x100)
+]) {
+    string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380CL_NICKNAME), string(STR_RELIABILITY, 5), string(STR_CRH380CL_CONSIST), string(STR_CRH380CL_HEAD_SEAT), string(STR_SPEED_AVAILABLE_2));
+}
 
 item (FEAT_TRAINS, crh380cl) {
     property {
@@ -190,7 +195,7 @@ item (FEAT_TRAINS, crh380cl) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380CL_NICKNAME), string(STR_RELIABILITY_5), string(STR_CRH380CL_CONSIST), string(STR_CRH380CL_HEAD_SEAT), string(STR_350_380_AVAILABLE));
+        additional_text:                switch_crh380cl_additional_text;
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh380_cargo_subtype;

--- a/src/25-emu/crh380d.pnml
+++ b/src/25-emu/crh380d.pnml
@@ -334,7 +334,7 @@ item (FEAT_TRAINS, crh380d) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380D_NICKNAME), string(STR_CRH380D_CONSIST), string(STR_RELIABILITY_5), string(STR_CRH380D_HEAD_SEAT));
+        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380D_NICKNAME), string(STR_CRH380D_CONSIST), string(STR_RELIABILITY, 5), string(STR_CRH380D_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         cargo_subtype_text:             switch_crh380_cargo_subtype;

--- a/src/25-emu/crh3a.pnml
+++ b/src/25-emu/crh3a.pnml
@@ -243,7 +243,7 @@ item (FEAT_TRAINS, crh3a) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH3A_NICKNAME), string(STR_RELIABILITY_8), string(STR_CRH3A_CONSIST), string(STR_CRH3A_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH3A_NICKNAME), string(STR_RELIABILITY, 8), string(STR_CRH3A_CONSIST), string(STR_CRH3A_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4car;
         // Graphics

--- a/src/25-emu/crh3c.pnml
+++ b/src/25-emu/crh3c.pnml
@@ -159,6 +159,11 @@ switch (FEAT_TRAINS, SELF, switch_crh3c_wagon_traction, vehicle_is_potentially_p
     return 0;
 }
 
+switch (FEAT_TRAINS, SELF, switch_crh3c_additional_text, [
+    STORE_TEMP(350, 0x100)
+]) {
+    string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH3C_NICKNAME), string(STR_RELIABILITY, 12), string(STR_CRH3C_CONSIST), string(STR_CRH3C_HEAD_SEAT), string(STR_SPEED_AVAILABLE_1));
+}
 
 item (FEAT_TRAINS, crh3c) {
     property {
@@ -201,7 +206,7 @@ item (FEAT_TRAINS, crh3c) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH3C_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH3C_CONSIST), string(STR_CRH3C_HEAD_SEAT), string(STR_350_AVAILABLE));
+        additional_text:                switch_crh3c_additional_text;
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh_c_cargo_subtype;

--- a/src/25-emu/crh5a.pnml
+++ b/src/25-emu/crh5a.pnml
@@ -323,7 +323,7 @@ item (FEAT_TRAINS, crh5a) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH5A_NICKNAME), string(STR_RELIABILITY_16), string(STR_CRH5A_CONSIST), string(STR_CRH5A_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH5A_NICKNAME), string(STR_RELIABILITY, 16), string(STR_CRH5A_CONSIST), string(STR_CRH5A_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu481216car;
         // Graphics

--- a/src/25-emu/crh6a2.pnml
+++ b/src/25-emu/crh6a2.pnml
@@ -353,7 +353,7 @@ item (FEAT_TRAINS, crh6a2) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH6A2_CAN_ATTACH_WAGON), string(STR_CRH6A2_LIVERY_AVAILABILITY), string(STR_RELIABILITY_8), string(STR_CRH6A2_CONSIST), string(STR_CRH6A2_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH6A2_CAN_ATTACH_WAGON), string(STR_CRH6A2_LIVERY_AVAILABILITY), string(STR_RELIABILITY, 8), string(STR_CRH6A2_CONSIST), string(STR_CRH6A2_HEAD_SEAT));
         can_attach_wagon:               onlyzezy;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh6a2_cargo_subtype;

--- a/src/25-emu/crh6a3.pnml
+++ b/src/25-emu/crh6a3.pnml
@@ -198,7 +198,7 @@ item (FEAT_TRAINS, crh6a3) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CRH6A3_CAN_ATTACH_WAGON), string(STR_CRH6A3_LIVERY_AVAILABILITY), string(STR_RELIABILITY_8), string(STR_CRH6A3_CONSIST), string(STR_CRH6A3_HEAD_SEAT));
+        additional_text:                string(STR_DESC_4, string(STR_CRH6A3_CAN_ATTACH_WAGON), string(STR_CRH6A3_LIVERY_AVAILABILITY), string(STR_RELIABILITY, 8), string(STR_CRH6A3_CONSIST), string(STR_CRH6A3_HEAD_SEAT));
         can_attach_wagon:               onlyze;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh6a3_cargo_subtype;

--- a/src/25-emu/crh6aa.pnml
+++ b/src/25-emu/crh6aa.pnml
@@ -206,7 +206,7 @@ item (FEAT_TRAINS, crh6aa) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_RELIABILITY_6), string(STR_CRH6AA_LIVERY_AVAILABILITY), string(STR_CRH6AA_CONSIST), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_4, string(STR_RELIABILITY, 6), string(STR_CRH6AA_LIVERY_AVAILABILITY), string(STR_CRH6AA_CONSIST), string(STR_COMFORT, 160));
         can_attach_wagon:               onlycrh6aa;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh6aa_cargo_subtype;

--- a/src/25-emu/crh6f.pnml
+++ b/src/25-emu/crh6f.pnml
@@ -209,7 +209,7 @@ item (FEAT_TRAINS, crh6f) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH6F_CAN_ATTACH_WAGON), string(STR_CRH6F_NICKNAME), string(STR_CRH6F_LIVERY_AVAILABILITY), string(STR_RELIABILITY_6), string(STR_CRH6F_CONSIST), string(STR_CRH6F_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH6F_CAN_ATTACH_WAGON), string(STR_CRH6F_NICKNAME), string(STR_CRH6F_LIVERY_AVAILABILITY), string(STR_RELIABILITY, 6), string(STR_CRH6F_CONSIST), string(STR_CRH6F_HEAD_SEAT));
         can_attach_wagon:               onlyze;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh6f_cargo_subtype;

--- a/src/25-emu/djj1.pnml
+++ b/src/25-emu/djj1.pnml
@@ -151,7 +151,7 @@ item (FEAT_TRAINS, djj1) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_DJJ1_LIVERY_AVAILABILITY), string(STR_DJJ1_CAN_ATTACH_WAGON), string(STR_DJJ1_CONSIST), string(STR_RELIABILITY_24));
+        additional_text:                string(STR_DESC_4, string(STR_DJJ1_LIVERY_AVAILABILITY), string(STR_DJJ1_CAN_ATTACH_WAGON), string(STR_DJJ1_CONSIST), string(STR_RELIABILITY, 24));
         can_attach_wagon:               djj1wagon;
         start_stop:                     switch_djj1_start_stop;
         cargo_subtype_text:             swtich_djj1_cargo_subtype;

--- a/src/coaches/19/rw19k.pnml
+++ b/src/coaches/19/rw19k.pnml
@@ -100,7 +100,7 @@ item (FEAT_TRAINS, rw19k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW19K), string(STR_19K_LIVERY_AVAILABILITY), string(STR_COMFORT_640));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW19K), string(STR_19K_LIVERY_AVAILABILITY), string(STR_COMFORT, 640));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rw19k_cargo_subtype;
 

--- a/src/coaches/19/rw19t.pnml
+++ b/src/coaches/19/rw19t.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rw19t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_FULL_NAME_RW19T), string(STR_COMFORT_640));
+        additional_text:                string(STR_DESC_2, string(STR_FULL_NAME_RW19T), string(STR_COMFORT, 640));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/22/ca23.pnml
+++ b/src/coaches/22/ca23.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, ca23) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA23), string(STR_CAFE_EFFECT), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_144_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA23), string(STR_CAFE_EFFECT), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_PREF, 144, string(STR_COMFORT_CAFE, 180)));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_ca23_cargo_subtype;
 

--- a/src/coaches/22/ca23aircon.pnml
+++ b/src/coaches/22/ca23aircon.pnml
@@ -91,7 +91,7 @@ item (FEAT_TRAINS, ca23aircon) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA23AIRCON), string(STR_CAFE_EFFECT), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_160_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA23AIRCON), string(STR_CAFE_EFFECT), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_PREF, 160, string(STR_COMFORT_CAFE, 200)));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_ca23aircon_cargo_subtype;
 

--- a/src/coaches/22/rw22.pnml
+++ b/src/coaches/22/rw22.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, rw22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT_384), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT, 384), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rw22_cargo_subtype;
 

--- a/src/coaches/22/rw22aircon.pnml
+++ b/src/coaches/22/rw22aircon.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, rw22aircon) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT, 384));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rw22aircon_cargo_subtype;
 

--- a/src/coaches/22/rz22.pnml
+++ b/src/coaches/22/rz22.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, rz22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RZ22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT_192), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RZ22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT, 192), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rz22_cargo_subtype;
 

--- a/src/coaches/22/rz22aircon.pnml
+++ b/src/coaches/22/rz22aircon.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, rz22aircon) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rz22aircon_cargo_subtype;
 

--- a/src/coaches/22/uz22.pnml
+++ b/src/coaches/22/uz22.pnml
@@ -95,7 +95,7 @@ item (FEAT_TRAINS, uz22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_UZ22), string(STR_22_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_UZ22), string(STR_22_LIVERY_AVAILABILITY), string(STR_DECAY, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_uz22_cargo_subtype;
 

--- a/src/coaches/22/xl22.pnml
+++ b/src/coaches/22/xl22.pnml
@@ -95,7 +95,7 @@ item (FEAT_TRAINS, xl22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL22), string(STR_22_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL22), string(STR_22_LIVERY_AVAILABILITY), string(STR_DECAY, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_xl22_cargo_subtype;
 

--- a/src/coaches/22/yw22aircon.pnml
+++ b/src/coaches/22/yw22aircon.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, yw22aircon) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT, 288));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_yw22aircon_cargo_subtype;
 

--- a/src/coaches/22/yz22.pnml
+++ b/src/coaches/22/yz22.pnml
@@ -86,7 +86,7 @@ item (FEAT_TRAINS, yz22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT_144), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT, 144), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_yz22_cargo_subtype;
 

--- a/src/coaches/22/yz22aircon.pnml
+++ b/src/coaches/22/yz22aircon.pnml
@@ -86,7 +86,7 @@ item (FEAT_TRAINS, yz22aircon) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_yz22aircon_cargo_subtype;
 

--- a/src/coaches/22b/rw22b.pnml
+++ b/src/coaches/22b/rw22b.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rw22b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW22B), string(STR_22B_LIVERY_AVAILABILITY), string(STR_COMFORT_384_AC), string(STR_SELF_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW22B), string(STR_22B_LIVERY_AVAILABILITY), string(STR_COMFORT_PREF, 384, string(STR_COMFORT_AC, 480)), string(STR_SELF_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/22b/yw22b.pnml
+++ b/src/coaches/22b/yw22b.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, yw22b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW22B), string(STR_22B_LIVERY_AVAILABILITY), string(STR_COMFORT_288), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW22B), string(STR_22B_LIVERY_AVAILABILITY), string(STR_COMFORT, 288), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/22b/yz22b.pnml
+++ b/src/coaches/22b/yz22b.pnml
@@ -67,7 +67,7 @@ item (FEAT_TRAINS, yz22b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ22B), string(STR_22B_LIVERY_AVAILABILITY), string(STR_COMFORT_144), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ22B), string(STR_22B_LIVERY_AVAILABILITY), string(STR_COMFORT, 144), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25/ca25ml.pnml
+++ b/src/coaches/25/ca25ml.pnml
@@ -90,7 +90,7 @@ item (FEAT_TRAINS, ca25ml) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25ML), string(STR_CAFE_EFFECT), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_160_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25ML), string(STR_CAFE_EFFECT), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_PREF, 160, string(STR_COMFORT_CAFE, 200)));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25/rw25ml.pnml
+++ b/src/coaches/25/rw25ml.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, rw25ml) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT, 384));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25/xl25ml.pnml
+++ b/src/coaches/25/xl25ml.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, xl25ml) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_DECAY, 200));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25/yw25ml.pnml
+++ b/src/coaches/25/yw25ml.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, yw25ml) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT, 288));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25/yz25ml.pnml
+++ b/src/coaches/25/yz25ml.pnml
@@ -86,7 +86,7 @@ item (FEAT_TRAINS, yz25ml) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT, 160));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25b/rw25b.pnml
+++ b/src/coaches/25b/rw25b.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rw25b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW25B), string(STR_RW25B_LIVERY_AVAILABILITY), string(STR_COMFORT_384_AC), string(STR_SELF_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW25B), string(STR_RW25B_LIVERY_AVAILABILITY), string(STR_COMFORT_PREF, 384, string(STR_COMFORT_AC, 480)), string(STR_SELF_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25b/rz25b.pnml
+++ b/src/coaches/25b/rz25b.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rz25b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RZ25B), string(STR_25B_LIVERY_AVAILABILITY), string(STR_COMFORT_192), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RZ25B), string(STR_25B_LIVERY_AVAILABILITY), string(STR_COMFORT, 192), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25b/srw25bhd.pnml
+++ b/src/coaches/25b/srw25bhd.pnml
@@ -53,7 +53,7 @@ item (FEAT_TRAINS, srw25bhd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRW25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRW25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT, 384));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25bhd_cargo_subtype;
 

--- a/src/coaches/25b/srz25bhd.pnml
+++ b/src/coaches/25b/srz25bhd.pnml
@@ -53,7 +53,7 @@ item (FEAT_TRAINS, srz25bhd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25bhd_cargo_subtype;
 

--- a/src/coaches/25b/srz25bld.pnml
+++ b/src/coaches/25b/srz25bld.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, srz25bld) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25B), string(STR_S25BLD_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25B), string(STR_S25BLD_LIVERY_AVAILABILITY), string(STR_COMFORT, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25bld_cargo_subtype;
 

--- a/src/coaches/25b/syw25bhd.pnml
+++ b/src/coaches/25b/syw25bhd.pnml
@@ -53,7 +53,7 @@ item (FEAT_TRAINS, syw25bhd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYW25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYW25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT, 288));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25bhd_cargo_subtype;
 

--- a/src/coaches/25b/syz25bhd.pnml
+++ b/src/coaches/25b/syz25bhd.pnml
@@ -86,7 +86,7 @@ item (FEAT_TRAINS, syz25bhd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25bhd_cargo_subtype;
 

--- a/src/coaches/25b/syz25bld.pnml
+++ b/src/coaches/25b/syz25bld.pnml
@@ -96,7 +96,7 @@ item (FEAT_TRAINS, syz25bld) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25B), string(STR_S25BLD_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25B), string(STR_S25BLD_LIVERY_AVAILABILITY), string(STR_COMFORT, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25bld_cargo_subtype;
 

--- a/src/coaches/25b/xl25b.pnml
+++ b/src/coaches/25b/xl25b.pnml
@@ -98,7 +98,7 @@ item (FEAT_TRAINS, xl25b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25B), string(STR_XL25B_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25B), string(STR_XL25B_LIVERY_AVAILABILITY), string(STR_DECAY, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_xl25b_cargo_subtype;
 

--- a/src/coaches/25b/yw25b.pnml
+++ b/src/coaches/25b/yw25b.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, yw25b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW25B), string(STR_25B_LIVERY_AVAILABILITY), string(STR_COMFORT_288), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW25B), string(STR_25B_LIVERY_AVAILABILITY), string(STR_COMFORT, 288), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25b/yz25b.pnml
+++ b/src/coaches/25b/yz25b.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, yz25b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ25B), string(STR_25B_LIVERY_AVAILABILITY), string(STR_COMFORT_144), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ25B), string(STR_25B_LIVERY_AVAILABILITY), string(STR_COMFORT, 144), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25dt/rw25dt_jinlun.pnml
+++ b/src/coaches/25dt/rw25dt_jinlun.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, rw25dt_jinlun) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT, 384));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_25dt_jinlun_cargo_subtype;
 

--- a/src/coaches/25dt/srz25dt_jinlun.pnml
+++ b/src/coaches/25dt/srz25dt_jinlun.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, srz25dt_jinlun) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SRZ25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SRZ25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_25dt_jinlun_cargo_subtype;
 

--- a/src/coaches/25dt/syz25dt_jinlun.pnml
+++ b/src/coaches/25dt/syz25dt_jinlun.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, syz25dt_jinlun) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SYZ25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SYZ25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_25dt_jinlun_cargo_subtype;
 

--- a/src/coaches/25dt/yw25dt_jinlun.pnml
+++ b/src/coaches/25dt/yw25dt_jinlun.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, yw25dt_jinlun) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT, 288));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_25dt_jinlun_cargo_subtype;
 

--- a/src/coaches/25dt/yz25dt_jinlun.pnml
+++ b/src/coaches/25dt/yz25dt_jinlun.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, yz25dt_jinlun) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_25dt_jinlun_cargo_subtype;
 

--- a/src/coaches/25g/ca25g.pnml
+++ b/src/coaches/25g/ca25g.pnml
@@ -98,7 +98,7 @@ item (FEAT_TRAINS, ca25g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25G), string(STR_CAFE_EFFECT), string(STR_CA25G_LIVERY_AVAILABILITY), string(STR_COMFORT_160_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25G), string(STR_CAFE_EFFECT), string(STR_CA25G_LIVERY_AVAILABILITY), string(STR_COMFORT_PREF, 160, string(STR_COMFORT_CAFE, 200)));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_ca25g_cargo_subtype;
 

--- a/src/coaches/25g/rw25g.pnml
+++ b/src/coaches/25g/rw25g.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rw25g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT, 384));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25g/rz25g.pnml
+++ b/src/coaches/25g/rz25g.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rz25g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT, 192));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25g/xl25g.pnml
+++ b/src/coaches/25g/xl25g.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, xl25g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_DECAY, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_xl25g_cargo_subtype;
 

--- a/src/coaches/25g/yw25g.pnml
+++ b/src/coaches/25g/yw25g.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, yw25g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT, 288));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25g/yz25g.pnml
+++ b/src/coaches/25g/yz25g.pnml
@@ -94,7 +94,7 @@ item (FEAT_TRAINS, yz25g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT, 160));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/ca25k.pnml
+++ b/src/coaches/25k/ca25k.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, ca25k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25K), string(STR_CAFE_EFFECT), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_160_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25K), string(STR_CAFE_EFFECT), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_PREF, 160, string(STR_COMFORT_CAFE, 200)));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/rw25k.pnml
+++ b/src/coaches/25k/rw25k.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rw25k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT, 384));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/rz25k.pnml
+++ b/src/coaches/25k/rz25k.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rz25k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT, 192));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/sca25khd.pnml
+++ b/src/coaches/25k/sca25khd.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, sca25khd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SCA25K), string(STR_SCA25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_160_CAFE), string(STR_CAFE_EFFECT));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SCA25K), string(STR_SCA25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_PREF, 160, string(STR_COMFORT_CAFE, 200)), string(STR_CAFE_EFFECT));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/srw25khd.pnml
+++ b/src/coaches/25k/srw25khd.pnml
@@ -73,7 +73,7 @@ item (FEAT_TRAINS, srw25khd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRW25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRW25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT, 384));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25khd_cargo_subtype;
 

--- a/src/coaches/25k/srz25khd.pnml
+++ b/src/coaches/25k/srz25khd.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, srz25khd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25khd_cargo_subtype;
 

--- a/src/coaches/25k/srz25kld.pnml
+++ b/src/coaches/25k/srz25kld.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, srz25kld) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25K), string(STR_S25KLD_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25K), string(STR_S25KLD_LIVERY_AVAILABILITY), string(STR_COMFORT, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25kld_cargo_subtype;
 

--- a/src/coaches/25k/syw25khd.pnml
+++ b/src/coaches/25k/syw25khd.pnml
@@ -73,7 +73,7 @@ item (FEAT_TRAINS, syw25khd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYW25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYW25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT, 288));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25khd_cargo_subtype;
 

--- a/src/coaches/25k/syz25khd.pnml
+++ b/src/coaches/25k/syz25khd.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, syz25khd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25khd_cargo_subtype;
 

--- a/src/coaches/25k/syz25kld.pnml
+++ b/src/coaches/25k/syz25kld.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, syz25kld) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25K), string(STR_S25KLD_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25K), string(STR_S25KLD_LIVERY_AVAILABILITY), string(STR_COMFORT, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25kld_cargo_subtype;
 

--- a/src/coaches/25k/xl25k.pnml
+++ b/src/coaches/25k/xl25k.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, xl25k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_DECAY, 200));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/yw25k.pnml
+++ b/src/coaches/25k/yw25k.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, yw25k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT, 288));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/yz25k.pnml
+++ b/src/coaches/25k/yz25k.pnml
@@ -67,7 +67,7 @@ item (FEAT_TRAINS, yz25k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT, 160));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25t/ca25t.pnml
+++ b/src/coaches/25t/ca25t.pnml
@@ -94,7 +94,7 @@ item (FEAT_TRAINS, ca25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25T), string(STR_CAFE_EFFECT), string(STR_CA25T_LIVERY_AVAILABILITY), string(STR_COMFORT_160_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25T), string(STR_CAFE_EFFECT), string(STR_CA25T_LIVERY_AVAILABILITY), string(STR_COMFORT_PREF, 160, string(STR_COMFORT_CAFE, 200)));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_ca25t_cargo_subtype;
 

--- a/src/coaches/25t/rw25t.pnml
+++ b/src/coaches/25t/rw25t.pnml
@@ -104,7 +104,7 @@ item (FEAT_TRAINS, rw25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25T), string(STR_BSP25T_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25T), string(STR_BSP25T_LIVERY_AVAILABILITY), string(STR_COMFORT, 384));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rw25t_cargo_subtype;
 

--- a/src/coaches/25t/rz25t.pnml
+++ b/src/coaches/25t/rz25t.pnml
@@ -101,7 +101,7 @@ item (FEAT_TRAINS, rz25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ25T), string(STR_BSP25T_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ25T), string(STR_BSP25T_LIVERY_AVAILABILITY), string(STR_COMFORT, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rz25t_cargo_subtype;
 

--- a/src/coaches/25t/uz25t.pnml
+++ b/src/coaches/25t/uz25t.pnml
@@ -96,7 +96,7 @@ item (FEAT_TRAINS, uz25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_UZ25T), string(STR_UZ25T_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_UZ25T), string(STR_UZ25T_LIVERY_AVAILABILITY), string(STR_DECAY, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_uz25t_cargo_subtype;
 

--- a/src/coaches/25t/xl25t.pnml
+++ b/src/coaches/25t/xl25t.pnml
@@ -102,7 +102,7 @@ item (FEAT_TRAINS, xl25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25T), string(STR_XL25T_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25T), string(STR_XL25T_LIVERY_AVAILABILITY), string(STR_DECAY, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_xl25t_cargo_subtype;
 

--- a/src/coaches/25t/xl25t_sspe.pnml
+++ b/src/coaches/25t/xl25t_sspe.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, xl25t_sspe) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_XL25T_SSPE_DESCRIPTION), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_2, string(STR_XL25T_SSPE_DESCRIPTION), string(STR_DECAY, 200));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25t/yw25t.pnml
+++ b/src/coaches/25t/yw25t.pnml
@@ -96,7 +96,7 @@ item (FEAT_TRAINS, yw25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25T), string(STR_25T_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25T), string(STR_25T_LIVERY_AVAILABILITY), string(STR_COMFORT, 288));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_yw25t_cargo_subtype;
 

--- a/src/coaches/25t/yz25t.pnml
+++ b/src/coaches/25t/yz25t.pnml
@@ -96,7 +96,7 @@ item (FEAT_TRAINS, yz25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25T), string(STR_25T_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25T), string(STR_25T_LIVERY_AVAILABILITY), string(STR_COMFORT, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_yz25t_cargo_subtype;
 

--- a/src/coaches/25z/ca25z.pnml
+++ b/src/coaches/25z/ca25z.pnml
@@ -90,7 +90,7 @@ item (FEAT_TRAINS, ca25z) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25Z), string(STR_CAFE_EFFECT), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_192_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25Z), string(STR_CAFE_EFFECT), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_PREF, 192, string(STR_COMFORT_CAFE, 240)));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_ca25z_cargo_subtype;
 

--- a/src/coaches/25z/rz125z.pnml
+++ b/src/coaches/25z/rz125z.pnml
@@ -95,7 +95,7 @@ item (FEAT_TRAINS, rz125z) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ125Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_256));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ125Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT, 256));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rz125z_cargo_subtype;
 

--- a/src/coaches/25z/rz225z.pnml
+++ b/src/coaches/25z/rz225z.pnml
@@ -91,7 +91,7 @@ item (FEAT_TRAINS, rz225z) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ225Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ225Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rz225z_cargo_subtype;
 

--- a/src/coaches/25z/rzt25z.pnml
+++ b/src/coaches/25z/rzt25z.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, rzt25z) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZT25Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_320));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZT25Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT, 320));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_rzt25z_graphics;

--- a/src/coaches/25z/rzxl25z.pnml
+++ b/src/coaches/25z/rzxl25z.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, rzxl25z) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZXL25Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZXL25Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_DECAY, 200));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_rzxl25z_graphics;

--- a/src/coaches/25z/sca25z.pnml
+++ b/src/coaches/25z/sca25z.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, sca25z) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SCA25Z), string(STR_CAFE_EFFECT), string(STR_S25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_192_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SCA25Z), string(STR_CAFE_EFFECT), string(STR_S25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_PREF, 192, string(STR_COMFORT_CAFE, 240)));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25z/srw25.pnml
+++ b/src/coaches/25z/srw25.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, srw25) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRW25), string(STR_S25_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRW25), string(STR_S25_LIVERY_AVAILABILITY), string(STR_COMFORT, 384));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_srw25_graphics;

--- a/src/coaches/25z/srz125z.pnml
+++ b/src/coaches/25z/srz125z.pnml
@@ -85,7 +85,7 @@ item (FEAT_TRAINS, srz125z) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ125Z), string(STR_S25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_256));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ125Z), string(STR_S25Z_LIVERY_AVAILABILITY), string(STR_COMFORT, 256));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_srz125z_cargo_subtype;
 

--- a/src/coaches/25z/srz225z.pnml
+++ b/src/coaches/25z/srz225z.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, srz225z) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ225Z), string(STR_S25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ225Z), string(STR_S25Z_LIVERY_AVAILABILITY), string(STR_COMFORT, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_srz225z_cargo_subtype;
 

--- a/src/coaches/25z/srzxl25z.pnml
+++ b/src/coaches/25z/srzxl25z.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, srzxl25z) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZXL25Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZXL25Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_DECAY, 200));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_srzxl25z_graphics;

--- a/src/coaches/25z/syw25.pnml
+++ b/src/coaches/25z/syw25.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, syw25) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYW25), string(STR_S25_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYW25), string(STR_S25_LIVERY_AVAILABILITY), string(STR_COMFORT, 288));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_syw25_graphics;

--- a/src/coaches/31/yz31.pnml
+++ b/src/coaches/31/yz31.pnml
@@ -80,7 +80,7 @@ item (FEAT_TRAINS, yz31) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ31), string(STR_YZ31_LIVERY_AVAILABILITY), string(STR_COMFORT_108), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ31), string(STR_YZ31_LIVERY_AVAILABILITY), string(STR_COMFORT, 108), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 //        cargo_subtype_text:             switch_yz31_cargo_subtype;
 

--- a/src/diesel/df.pnml
+++ b/src/diesel/df.pnml
@@ -95,7 +95,7 @@ item (FEAT_TRAINS, df) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_FULL_NAME_DF),  string(STR_ALIASNAME_DF), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF_LIVERY_AVAILABILITY), string(STR_DF_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_6, string(STR_FULL_NAME_DF),  string(STR_ALIASNAME_DF), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF_LIVERY_AVAILABILITY), string(STR_DF_NICKNAME), string(STR_RELIABILITY, 16));
         cargo_subtype_text:             switch_df_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df11.pnml
+++ b/src/diesel/df11.pnml
@@ -65,7 +65,7 @@ item (FEAT_TRAINS, df11) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF11), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF11_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF11), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF11_NICKNAME), string(STR_RELIABILITY, 10));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/diesel/df11g.pnml
+++ b/src/diesel/df11g.pnml
@@ -111,7 +111,7 @@ item (FEAT_TRAINS, df11g) {
     }
     graphics {
         // Menu
-        additional_text:                        string(STR_DESC_6, string(STR_FULL_NAME_DF11G), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_DF11G_NICKNAME), string(STR_RELIABILITY_6), string(STR_DF11G_CONSIST), string(STR_LEAPING_LIU_NEVER_DIES));
+        additional_text:                        string(STR_DESC_6, string(STR_FULL_NAME_DF11G), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_DF11G_NICKNAME), string(STR_RELIABILITY, 6), string(STR_DF11G_CONSIST), string(STR_LEAPING_LIU_NEVER_DIES));
         can_attach_wagon:                       locowagon;
 
         // Graphics

--- a/src/diesel/df11z.pnml
+++ b/src/diesel/df11z.pnml
@@ -66,7 +66,7 @@ item (FEAT_TRAINS, df11z) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF11Z), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF11Z), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY, 14));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_df11z_graphics;

--- a/src/diesel/df4bh.pnml
+++ b/src/diesel/df4bh.pnml
@@ -106,7 +106,7 @@ item (FEAT_TRAINS, df4bh) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4B_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4B_NICKNAME), string(STR_RELIABILITY, 14));
         cargo_subtype_text:             switch_df4bh_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4bk.pnml
+++ b/src/diesel/df4bk.pnml
@@ -93,7 +93,7 @@ item (FEAT_TRAINS, df4bk) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4B_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4B_NICKNAME), string(STR_RELIABILITY, 14));
         cargo_subtype_text:             switch_df4bk_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4c.pnml
+++ b/src/diesel/df4c.pnml
@@ -85,7 +85,7 @@ item (FEAT_TRAINS, df4c) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4C), string(STR_ALIASNAME_DF), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4C_LIVERY_AVAILABILITY), string(STR_DF4C_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4C), string(STR_ALIASNAME_DF), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4C_LIVERY_AVAILABILITY), string(STR_DF4C_NICKNAME), string(STR_RELIABILITY, 16));
         cargo_subtype_text:             switch_df4c_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4d0000.pnml
+++ b/src/diesel/df4d0000.pnml
@@ -87,7 +87,7 @@ item (FEAT_TRAINS, df4d0000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4D), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D0000_LIVERY_AVAILABILITY), string(STR_DF4D_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4D), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D0000_LIVERY_AVAILABILITY), string(STR_DF4D_NICKNAME), string(STR_RELIABILITY, 14));
         cargo_subtype_text:             switch_df4d0000_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4d3000.pnml
+++ b/src/diesel/df4d3000.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, df4d3000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF4D), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF4D), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D_NICKNAME), string(STR_RELIABILITY, 14));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/diesel/df4d4000.pnml
+++ b/src/diesel/df4d4000.pnml
@@ -93,7 +93,7 @@ item (FEAT_TRAINS, df4d4000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4D), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D4000_LIVERY_AVAILABILITY), string(STR_DF4D_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4D), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D4000_LIVERY_AVAILABILITY), string(STR_DF4D_NICKNAME), string(STR_RELIABILITY, 14));
         cargo_subtype_text:             switch_df4d4000_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4d7000.pnml
+++ b/src/diesel/df4d7000.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, df4d7000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF4D7000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D7000_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF4D7000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D7000_NICKNAME), string(STR_RELIABILITY, 10));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/diesel/df4df.pnml
+++ b/src/diesel/df4df.pnml
@@ -85,7 +85,7 @@ item (FEAT_TRAINS, df4df) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4DF), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_DF4DF_LIVERY_AVAILABILITY), string(STR_DF4D_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4DF), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_DF4DF_LIVERY_AVAILABILITY), string(STR_DF4D_NICKNAME), string(STR_RELIABILITY, 16));
         cargo_subtype_text:             switch_df4df_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4e.pnml
+++ b/src/diesel/df4e.pnml
@@ -83,7 +83,7 @@ item (FEAT_TRAINS, df4e) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF4E), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF4E), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY, 14));
         cargo_subtype_text:             switch_df4e_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4h.pnml
+++ b/src/diesel/df4h.pnml
@@ -72,7 +72,7 @@ item (FEAT_TRAINS, df4h) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4_NICKNAME), string(STR_RELIABILITY_32));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4_NICKNAME), string(STR_RELIABILITY, 32));
         cargo_subtype_text:             switch_df4h_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4k.pnml
+++ b/src/diesel/df4k.pnml
@@ -129,7 +129,7 @@ item (FEAT_TRAINS, df4k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4_NICKNAME), string(STR_RELIABILITY_32));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4_NICKNAME), string(STR_RELIABILITY, 32));
         cargo_subtype_text:             switch_df4k_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df5.pnml
+++ b/src/diesel/df5.pnml
@@ -95,7 +95,7 @@ item (FEAT_TRAINS, df5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY, 16));
         cargo_subtype_text:             switch_df5_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df5kz.pnml
+++ b/src/diesel/df5kz.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, df5kz) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF5KZ), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_20));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF5KZ), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY, 20));
         cargo_subtype_text:             switch_df5kz_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df7g.pnml
+++ b/src/diesel/df7g.pnml
@@ -67,7 +67,7 @@ item (FEAT_TRAINS, df7g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF7G), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF7G_NICKNAME), string(STR_RELIABILITY_20));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF7G), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF7G_NICKNAME), string(STR_RELIABILITY, 20));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_df7g_graphics;

--- a/src/diesel/df7g5000.pnml
+++ b/src/diesel/df7g5000.pnml
@@ -82,7 +82,7 @@ item (FEAT_TRAINS, df7g5000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF7G), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF7G5000_LIVERY_AVAILABILITY), string(STR_DF7G_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF7G), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF7G5000_LIVERY_AVAILABILITY), string(STR_DF7G_NICKNAME), string(STR_RELIABILITY, 16));
         cargo_subtype_text:             switch_df7g5000_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df7g8000.pnml
+++ b/src/diesel/df7g8000.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, df7g8000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF7G8000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF7G_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF7G8000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF7G_NICKNAME), string(STR_RELIABILITY, 16));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_df7g8000_graphics;

--- a/src/diesel/df8b.pnml
+++ b/src/diesel/df8b.pnml
@@ -77,7 +77,7 @@ item (FEAT_TRAINS, df8b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF8B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF8B_LIVERY_AVAILABILITY), string(STR_DF8B_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF8B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF8B_LIVERY_AVAILABILITY), string(STR_DF8B_NICKNAME), string(STR_RELIABILITY, 14));
         cargo_subtype_text:             switch_df8b_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/dfh7.pnml
+++ b/src/diesel/dfh7.pnml
@@ -87,7 +87,7 @@ item (FEAT_TRAINS, dfh7) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DFH7), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_24));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DFH7), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY, 24));
         cargo_subtype_text:             switch_dfh7_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/diesel/hxn3.pnml
+++ b/src/diesel/hxn3.pnml
@@ -87,7 +87,7 @@ item (FEAT_TRAINS, hxn3) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_HXN3), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_HXN3), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY, 8));
         cargo_subtype_text:             switch_hxn3_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/hxn3qz.pnml
+++ b/src/diesel/hxn3qz.pnml
@@ -110,7 +110,7 @@ item (FEAT_TRAINS, hxn3qz) {
     }
     graphics {
         // Menu
-        additional_text:                        string(STR_DESC_3, string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_8), string(STR_HXN3QZ_CONSIST));
+        additional_text:                        string(STR_DESC_3, string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY, 8), string(STR_HXN3QZ_CONSIST));
         can_attach_wagon:                       locowagon;
         cargo_subtype_text:                     switch_hxn3qz_cargo_subtype;
 

--- a/src/diesel/hxn5.pnml
+++ b/src/diesel/hxn5.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, hxn5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXN5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXN5_NICKNAME), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXN5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXN5_NICKNAME), string(STR_RELIABILITY, 8));
         cargo_subtype_text:             switch_hxn5_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/hxn5b.pnml
+++ b/src/diesel/hxn5b.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, hxn5b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXN5B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXN5B_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXN5B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXN5B_NICKNAME), string(STR_RELIABILITY, 14));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxn5b_graphics;

--- a/src/diesel/nd5.pnml
+++ b/src/diesel/nd5.pnml
@@ -88,7 +88,7 @@ item (FEAT_TRAINS, nd5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_ND5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_ND5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY, 14));
         cargo_subtype_text:             switch_nd5_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/nj2.pnml
+++ b/src/diesel/nj2.pnml
@@ -113,7 +113,7 @@ item (FEAT_TRAINS, nj2) {
     }
     graphics {
         // Menu
-        additional_text:                        string(STR_DESC_5, string(STR_US_IMPORT), string(STR_NJ2_LIVERY_AVAILABILITY), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_8), string(STR_NJ2_CONSIST));
+        additional_text:                        string(STR_DESC_5, string(STR_US_IMPORT), string(STR_NJ2_LIVERY_AVAILABILITY), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY, 8), string(STR_NJ2_CONSIST));
         can_attach_wagon:                       locowagon;
         cargo_subtype_text:                     switch_nj2_cargo_subtype;
 

--- a/src/dmu/nc3.pnml
+++ b/src/dmu/nc3.pnml
@@ -210,7 +210,7 @@ item (FEAT_TRAINS, nc3) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_NC3_CAN_ATTACH_WAGON), string(STR_NC3_CONSIST), string(STR_HU_IMPORT), string(STR_COMFORT, 185), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_5, string(STR_NC3_CAN_ATTACH_WAGON), string(STR_NC3_CONSIST), string(STR_HU_IMPORT), string(STR_COMFORT, 185), string(STR_RELIABILITY, 16));
         can_attach_wagon:               onlyze;
         start_stop:                     mu2to16car;
 

--- a/src/dmu/ndj3.pnml
+++ b/src/dmu/ndj3.pnml
@@ -124,7 +124,7 @@ item (FEAT_TRAINS, ndj3) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_NDJ3_NICKNAME), string(STR_NDJ3_CAN_ATTACH_WAGON), string(STR_NDJ3_CONSIST), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_NDJ3_NICKNAME), string(STR_NDJ3_CAN_ATTACH_WAGON), string(STR_NDJ3_CONSIST), string(STR_RELIABILITY, 6));
         can_attach_wagon:               ndj3wagon;
         start_stop:                     switch_ndj3_start_stop;
 

--- a/src/dmu/nzj1_xinshuguang.pnml
+++ b/src/dmu/nzj1_xinshuguang.pnml
@@ -110,7 +110,7 @@ item (FEAT_TRAINS, nzj1_xinshuguang) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_NZJ1_XINSHUGUANG_CAN_ATTACH_WAGON), string(STR_NZJ1_XINSHUGUANG_CONSIST), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_3, string(STR_NZJ1_XINSHUGUANG_CAN_ATTACH_WAGON), string(STR_NZJ1_XINSHUGUANG_CONSIST), string(STR_RELIABILITY, 16));
         can_attach_wagon:               nzj1_xinshuguang_wagon;
         start_stop:                     switch_nzj1_xinshuguang_start_stop;
 

--- a/src/dmu/nzj2_jinlun_double_decker.pnml
+++ b/src/dmu/nzj2_jinlun_double_decker.pnml
@@ -94,7 +94,7 @@ item (FEAT_TRAINS, nzj2_jinlun_2) {
     }
     graphics {
         // Menu
-        additional_text:                        string(STR_DESC_3, string(STR_JINLUN_LOCOMOTIVE_CONSIST), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_RELIABILITY_20));
+        additional_text:                        string(STR_DESC_3, string(STR_JINLUN_LOCOMOTIVE_CONSIST), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_RELIABILITY, 20));
         can_attach_wagon:                       switch_nzj2_jinlun_2_can_attach_wagon;
         start_stop:                             switch_nzj2_jinlun_2_start_stop;
         // Graphics

--- a/src/dmu/nzj2_jinlun_unilaminar.pnml
+++ b/src/dmu/nzj2_jinlun_unilaminar.pnml
@@ -91,7 +91,7 @@ item (FEAT_TRAINS, nzj2_jinlun_1) {
     }
     graphics {
         // Menu
-        additional_text:                        string(STR_DESC_3, string(STR_JINLUN_LOCOMOTIVE_CONSIST), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_RELIABILITY_20));
+        additional_text:                        string(STR_DESC_3, string(STR_JINLUN_LOCOMOTIVE_CONSIST), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_RELIABILITY, 20));
         can_attach_wagon:                       switch_nzj2_jinlun_1_can_attach_wagon;
         start_stop:                             switch_nzj2_jinlun_1_start_stop;
         // Graphics

--- a/src/functions.pnml
+++ b/src/functions.pnml
@@ -215,7 +215,7 @@ switch (FEAT_TRAINS, SELF, mu4car, num_vehs_in_consist < 12) {
 // MUs need at least 2 and at most 16 cars to start
 
 switch (FEAT_TRAINS, SELF, mu2to16car, (num_vehs_in_consist < 6) || (num_vehs_in_consist > 48)) {
-    1: return string(STR_MUST_BE_2_TO_16_CARS);
+    1: return string(STR_MUST_BE_RANGE_CARS, 2, 16);
     return CB_RESULT_NO_TEXT;
 }
 
@@ -223,14 +223,14 @@ switch (FEAT_TRAINS, SELF, mu2to16car, (num_vehs_in_consist < 6) || (num_vehs_in
 // MUs need at least 4 and at most 24 cars to start
 
 switch (FEAT_TRAINS, SELF, mu4to24car, (num_vehs_in_consist < 12) || (num_vehs_in_consist > 72)) {
-    1: return string(STR_MUST_BE_4_TO_24_CARS);
+    1: return string(STR_MUST_BE_RANGE_CARS, 4, 24);
     return CB_RESULT_NO_TEXT;
 }
 
 // MUs need at least 8 and at most 24 cars to start
 
 switch (FEAT_TRAINS, SELF, mu8to24car, (num_vehs_in_consist < 12) || (num_vehs_in_consist > 72)) {
-    1: return string(STR_MUST_BE_8_TO_24_CARS);
+    1: return string(STR_MUST_BE_RANGE_CARS, 8, 24);
     return CB_RESULT_NO_TEXT;
 }
 
@@ -250,7 +250,7 @@ switch (FEAT_TRAINS, SELF, mu481216car, num_vehs_in_consist) {
 
 switch (FEAT_TRAINS, SELF, mu5to17car, num_vehs_in_consist) {
     15..51: return CB_RESULT_NO_TEXT;
-    return string(STR_MUST_BE_5_TO_17_CARS);
+    return string(STR_MUST_BE_RANGE_CARS, 5, 17);
 }
 
 /* LENGTHS */

--- a/src/header.pnml
+++ b/src/header.pnml
@@ -15,10 +15,10 @@ grf {
             max_value: 3;
             def_value: 1;
             names: {
-                0: string(STR_PARAM_DIVIDE_2);
-                1: string(STR_PARAM_NORMAL);
-                2: string(STR_PARAM_TIMES_2);
-                3: string(STR_PARAM_TIMES_4);
+                0: string(STR_PERCENTAGE, 50);
+                1: string(STR_PERCENTAGE, 100);
+                2: string(STR_PERCENTAGE, 200);
+                3: string(STR_PERCENTAGE, 400);
             };
         }
     }
@@ -31,15 +31,15 @@ grf {
             max_value: 8;
             def_value: 2;
             names: {
-                0: string(STR_PARAM_DIVIDE_16);
-                1: string(STR_PARAM_DIVIDE_8);
-                2: string(STR_PARAM_DIVIDE_4);
-                3: string(STR_PARAM_DIVIDE_2);
-                4: string(STR_PARAM_NORMAL);
-                5: string(STR_PARAM_TIMES_2);
-                6: string(STR_PARAM_TIMES_4);
-                7: string(STR_PARAM_TIMES_8);
-                8: string(STR_PARAM_TIMES_16);
+                0: string(STR_PERCENTAGE, 6);
+                1: string(STR_PERCENTAGE, 12);
+                2: string(STR_PERCENTAGE, 25);
+                3: string(STR_PERCENTAGE, 50);
+                4: string(STR_PERCENTAGE, 100);
+                5: string(STR_PERCENTAGE, 200);
+                6: string(STR_PERCENTAGE, 400);
+                7: string(STR_PERCENTAGE, 800);
+                8: string(STR_PERCENTAGE, 1600);
             };
         }
     }
@@ -52,15 +52,15 @@ grf {
             max_value: 8;
             def_value: 2;
             names: {
-                0: string(STR_PARAM_DIVIDE_16);
-                1: string(STR_PARAM_DIVIDE_8);
-                2: string(STR_PARAM_DIVIDE_4);
-                3: string(STR_PARAM_DIVIDE_2);
-                4: string(STR_PARAM_NORMAL);
-                5: string(STR_PARAM_TIMES_2);
-                6: string(STR_PARAM_TIMES_4);
-                7: string(STR_PARAM_TIMES_8);
-                8: string(STR_PARAM_TIMES_16);
+                0: string(STR_PERCENTAGE, 6);
+                1: string(STR_PERCENTAGE, 12);
+                2: string(STR_PERCENTAGE, 25);
+                3: string(STR_PERCENTAGE, 50);
+                4: string(STR_PERCENTAGE, 100);
+                5: string(STR_PERCENTAGE, 200);
+                6: string(STR_PERCENTAGE, 400);
+                7: string(STR_PERCENTAGE, 800);
+                8: string(STR_PERCENTAGE, 1600);
             };
         }
     }

--- a/src/steam/sy.pnml
+++ b/src/steam/sy.pnml
@@ -68,7 +68,7 @@ item (FEAT_TRAINS, sy) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SY), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_12));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SY), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY, 12));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/unit-wagons-rail/swmuw.pnml
+++ b/src/unit-wagons-rail/swmuw.pnml
@@ -49,7 +49,7 @@ item (FEAT_TRAINS, swmuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_720));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT, 720));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/wemuw.pnml
+++ b/src/unit-wagons-rail/wemuw.pnml
@@ -50,7 +50,7 @@ item (FEAT_TRAINS, wemuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_CR200J), string(STR_COMFORT_480));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_CR200J), string(STR_COMFORT, 480));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/wgmuw.pnml
+++ b/src/unit-wagons-rail/wgmuw.pnml
@@ -50,7 +50,7 @@ item (FEAT_TRAINS, wgmuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_SLEEPER_MU), string(STR_COMFORT_800));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_SLEEPER_MU), string(STR_COMFORT, 800));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/wymuw.pnml
+++ b/src/unit-wagons-rail/wymuw.pnml
@@ -50,7 +50,7 @@ item (FEAT_TRAINS, wymuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_SLEEPER_MU), string(STR_COMFORT_640));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_SLEEPER_MU), string(STR_COMFORT, 640));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/zecmuw.pnml
+++ b/src/unit-wagons-rail/zecmuw.pnml
@@ -51,7 +51,7 @@ item (FEAT_TRAINS, zecmuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_CAFE_EFFECT), string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_240_CAFE));
+        additional_text:                string(STR_DESC_3, string(STR_CAFE_EFFECT), string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_PREF, 240, string(STR_COMFORT_CAFE, 300)));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/zemuw.pnml
+++ b/src/unit-wagons-rail/zemuw.pnml
@@ -62,7 +62,7 @@ item (FEAT_TRAINS, zemuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_240));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT, 240));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/zsmuw.pnml
+++ b/src/unit-wagons-rail/zsmuw.pnml
@@ -50,7 +50,7 @@ item (FEAT_TRAINS, zsmuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_640));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT, 640));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/zymuw.pnml
+++ b/src/unit-wagons-rail/zymuw.pnml
@@ -50,7 +50,7 @@ item (FEAT_TRAINS, zymuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_400));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT, 400));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/wagons/b22.pnml
+++ b/src/wagons/b22.pnml
@@ -85,7 +85,7 @@ item (FEAT_TRAINS, b22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_1600);
+        additional_text:                string(STR_DECAY, 1600);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/b6.pnml
+++ b/src/wagons/b6.pnml
@@ -78,7 +78,7 @@ item (FEAT_TRAINS, b6) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_800);
+        additional_text:                string(STR_DECAY, 800);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/c62.pnml
+++ b/src/wagons/c62.pnml
@@ -97,7 +97,7 @@ item (FEAT_TRAINS, c62) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_C62_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_C62_LIVERY_AVAILABILITY), string(STR_DECAY, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/c64.pnml
+++ b/src/wagons/c64.pnml
@@ -99,7 +99,7 @@ item (FEAT_TRAINS, c64) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_C64_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_C64_LIVERY_AVAILABILITY), string(STR_DECAY, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/c70.pnml
+++ b/src/wagons/c70.pnml
@@ -125,7 +125,7 @@ item (FEAT_TRAINS, c70) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_C70_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_C70_LIVERY_AVAILABILITY), string(STR_DECAY, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/g17.pnml
+++ b/src/wagons/g17.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, g17) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_G17_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_G17_LIVERY_AVAILABILITY), string(STR_DECAY, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/g50.pnml
+++ b/src/wagons/g50.pnml
@@ -67,7 +67,7 @@ item (FEAT_TRAINS, g50) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_185);
+        additional_text:                string(STR_DECAY, 185);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/g60.pnml
+++ b/src/wagons/g60.pnml
@@ -74,7 +74,7 @@ item (FEAT_TRAINS, g60) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_G60_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_G60_LIVERY_AVAILABILITY), string(STR_DECAY, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/gn70.pnml
+++ b/src/wagons/gn70.pnml
@@ -78,7 +78,7 @@ item (FEAT_TRAINS, gn70) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_GN70_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_GN70_LIVERY_AVAILABILITY), string(STR_DECAY, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/gn80.pnml
+++ b/src/wagons/gn80.pnml
@@ -74,7 +74,7 @@ item (FEAT_TRAINS, gn80) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_GN80_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_GN80_LIVERY_AVAILABILITY), string(STR_DECAY, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/j5.pnml
+++ b/src/wagons/j5.pnml
@@ -93,7 +93,7 @@ item (FEAT_TRAINS, j5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_800);
+        additional_text:                string(STR_DECAY, 800);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/jsq5.pnml
+++ b/src/wagons/jsq5.pnml
@@ -74,7 +74,7 @@ item (FEAT_TRAINS, jsq5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_400);
+        additional_text:                string(STR_DECAY, 400);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/jsq6.pnml
+++ b/src/wagons/jsq6.pnml
@@ -77,7 +77,7 @@ item (FEAT_TRAINS, jsq6) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_400);
+        additional_text:                string(STR_DECAY, 400);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/l70.pnml
+++ b/src/wagons/l70.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, l70) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_185);
+        additional_text:                string(STR_DECAY, 185);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/n5.pnml
+++ b/src/wagons/n5.pnml
@@ -172,7 +172,7 @@ item (FEAT_TRAINS, n5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_N5_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_N5_LIVERY_AVAILABILITY), string(STR_DECAY, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/n60.pnml
+++ b/src/wagons/n60.pnml
@@ -93,7 +93,7 @@ item (FEAT_TRAINS, n60) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_N60_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_N60_LIVERY_AVAILABILITY), string(STR_DECAY, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/nx17.pnml
+++ b/src/wagons/nx17.pnml
@@ -1146,7 +1146,7 @@ item (FEAT_TRAINS, nx17) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_NX17_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_NX17_LIVERY_AVAILABILITY), string(STR_DECAY, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/nx70a.pnml
+++ b/src/wagons/nx70a.pnml
@@ -605,7 +605,7 @@ item (FEAT_TRAINS, nx70a) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_NX70A_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_NX70A_LIVERY_AVAILABILITY), string(STR_DECAY, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/p50.pnml
+++ b/src/wagons/p50.pnml
@@ -144,7 +144,7 @@ item (FEAT_TRAINS, p50) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_P50_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR), string(STR_DESC_PENGDAIKE));
+        additional_text:                string(STR_DESC_3, string(STR_P50_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR, 185, 80, 560), string(STR_DESC_PENGDAIKE));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_p50_cargo_subtype;
 

--- a/src/wagons/p60.pnml
+++ b/src/wagons/p60.pnml
@@ -104,7 +104,7 @@ item (FEAT_TRAINS, p60) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_P60_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR), string(STR_DESC_PENGDAIKE));
+        additional_text:                string(STR_DESC_3, string(STR_P60_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR, 185, 80, 560), string(STR_DESC_PENGDAIKE));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/p61.pnml
+++ b/src/wagons/p61.pnml
@@ -104,7 +104,7 @@ item (FEAT_TRAINS, p61) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_P61_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR), string(STR_DESC_PENGDAIKE));
+        additional_text:                string(STR_DESC_3, string(STR_P61_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR, 185, 80, 560), string(STR_DESC_PENGDAIKE));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/p62.pnml
+++ b/src/wagons/p62.pnml
@@ -168,7 +168,7 @@ item (FEAT_TRAINS, p62) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_P62_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR), string(STR_DESC_PENGDAIKE));
+        additional_text:                string(STR_DESC_3, string(STR_P62_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR, 185, 80, 560), string(STR_DESC_PENGDAIKE));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/p63.pnml
+++ b/src/wagons/p63.pnml
@@ -112,7 +112,7 @@ item (FEAT_TRAINS, p63) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_P63_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR), string(STR_DESC_PENGDAIKE));
+        additional_text:                string(STR_DESC_3, string(STR_P63_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR, 185, 80, 560), string(STR_DESC_PENGDAIKE));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/p65.pnml
+++ b/src/wagons/p65.pnml
@@ -85,7 +85,7 @@ item (FEAT_TRAINS, p65) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_P65_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR_NOPASS));
+        additional_text:                string(STR_DESC_2, string(STR_P65_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR_NOPAX, 185, 560));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/p70.pnml
+++ b/src/wagons/p70.pnml
@@ -128,7 +128,7 @@ item (FEAT_TRAINS, p70) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_P70_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR_NOPASS));
+        additional_text:                string(STR_DESC_2, string(STR_P70_LIVERY_AVAILABILITY), string(STR_DECAY_BOXCAR_NOPAX, 185, 560));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/p80.pnml
+++ b/src/wagons/p80.pnml
@@ -91,7 +91,7 @@ item (FEAT_TRAINS, p80) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_DECAY_BOXCAR_NOPASS));
+        additional_text:                string(STR_DESC_2, string(STR_DECAY_BOXCAR_NOPAX, 185, 560));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/pb.pnml
+++ b/src/wagons/pb.pnml
@@ -87,7 +87,7 @@ item (FEAT_TRAINS, pb) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_DECAY_BOXCAR_NOPASS));
+        additional_text:                string(STR_DESC_2, string(STR_DECAY_BOXCAR_NOPAX, 185, 560));
         can_attach_wagon:               locowagon;
 
         // Graphics


### PR DESCRIPTION
It would be nice to have a shorter langauge file, so I made this.
Also added a few switches in crh380 and crh2 & 3 code so the unit used automatically syncs with the player's setting.

Script used:
```py
import glob
import re

rules = {
    # common
    r"string\s*\(\s*STR_COMFORT_(\d+)\s*\)": r"string(STR_COMFORT, \g<1>)",
    r"string\s*\(\s*STR_MUST_BE_(\d+)_TO_(\d+)_CARS\s*\)": r"string(STR_MUST_BE_RANGE_CARS, \g<1>, \g<2>)",
    r"string\s*\(\s*STR_DECAY_(\d+)\s*\)": r"string(STR_DECAY, \g<1>)",
    r"string\s*\(\s*STR_RELIABILITY_(\d+)\s*\)": r"string(STR_RELIABILITY, \g<1>)",
    r"string\s*\(\s*STR_PARAM_DIVIDE_(\d+)\s*\)": lambda m: f"string(STR_PERCENTAGE, {int(100 / int(m.group(1)))})",
    r"string\s*\(\s*STR_PARAM_TIMES_(\d+)\s*\)": lambda m: f"string(STR_PERCENTAGE, {int(100 * int(m.group(1)))})",
    r"string\s*\(\s*STR_PARAM_NORMAL\s*\)": r"string(STR_PERCENTAGE, 100)",
    # special
    r"string\s*\(\s*STR_COMFORT_144_CAFE\s*\)": r"string(STR_COMFORT_PREF, 144, string(STR_COMFORT_CAFE, 180))",
    r"string\s*\(\s*STR_COMFORT_160_CAFE\s*\)": r"string(STR_COMFORT_PREF, 160, string(STR_COMFORT_CAFE, 200))",
    r"string\s*\(\s*STR_COMFORT_192_CAFE\s*\)": r"string(STR_COMFORT_PREF, 192, string(STR_COMFORT_CAFE, 240))",
    r"string\s*\(\s*STR_COMFORT_240_CAFE\s*\)": r"string(STR_COMFORT_PREF, 240, string(STR_COMFORT_CAFE, 300))",
    r"string\s*\(\s*STR_COMFORT_384_AC\s*\)": r"string(STR_COMFORT_PREF, 384, string(STR_COMFORT_AC, 480))",
    r"string\s*\(\s*STR_DECAY_BOXCAR\s*\)": r"string(STR_DECAY_BOXCAR, 185, 80, 560)",
    r"string\s*\(\s*STR_DECAY_BOXCAR_NOPASS\s*\)": r"string(STR_DECAY_BOXCAR_NOPAX, 185, 560)",
}

special_rules = {
    # rules that are special enough that would need manual fixing
    # in this case we are not replacing anything, so we just print the line
    # r"string\s*\(\s*STR_\d+_KMH\s*\)"
    r"string\s*\(\s*STR_[\d_]+_AVAILABLE\s*\)"
}

# recursively search for all files in the directory
files = glob.glob("**/*.pnml", recursive=True)

for file in files:
    new_lines = []
    with open(file, "r", encoding="utf-8") as f:
        for i,line in enumerate(f):
            for regex, replacement in rules.items():
                line = re.sub(regex, replacement, line)
            for regex in special_rules:
                if re.search(regex, line):
                    print(f"Special rule found in {file}:{i+1}")
            new_lines.append(line)
    with open(file, "w", encoding="utf-8") as f:
        f.writelines(new_lines)


```