### PR TITLE
Improve language strings for reliability decay speed and cargo age period (comfort/freshness)

### DIFF
--- a/docs/changelog.txt
+++ b/docs/changelog.txt
@@ -5,15 +5,16 @@ China Set: Trains Changelog
 
 ## Initial-0-3 Updates
 
-0.3.1.169 (8/17/2024)
+0.3.1.168 (18/8/2024)
 --------------------
 Add: HXD2, HXD2-1000, CHA1C, SS4B, SS4C
-Renewl the sprites of SS3, SS4, SS4G, DF11, HXN5
+Renewal the sprites of SS3, SS4, SS4G, DF11, HXN5
 Add Livery: CR400BF-C Winter Olympic, CR400BF-Z Asia Game
+Feature: improved language strings of reliability decay and comfort
 
 0.3.1.167 (8/8/2024)
 --------------------
-Add: NC3, P80, UZ25T, P50，P65
+Add: NC3, P80, UZ25T, P50, P65
 Renewl the sprites of HXD1D, 25T
 Wagons with aging liveries now have new feature: The probabilities of aging liveries will change by years
 Fix #47: The Cargo Tyoe of PB

--- a/docs/str.CSV
+++ b/docs/str.CSV
@@ -342,7 +342,7 @@ STR_FULL_NAME_DF4D,{BLACK}FULLNAME: {GOLD}Dongfeng 4D Diesel Locomotive,{BLACK}�
 STR_FULL_NAME_DF4D7000,{BLACK}FULLNAME: {GOLD}Dongfeng 4D Diesel Locomotive 7000 Series,{BLACK}全称：{GOLD}东风4D型内燃机车7000系
 STR_FULL_NAME_DF4DF,{BLACK}FULLNAME: {GOLD}Dongfeng 4DF Diesel Locomotive,{BLACK}全称：{GOLD}东风4DF型内燃机车
 STR_FULL_NAME_DF4E,{BLACK}FULLNAME: {GOLD}Dongfeng 4E Diesel Locomotive,{BLACK}全称：{GOLD}东风4E型内燃机车
-STR_FULL_NAME_DF5KZ,{BLACK}FULLNAME: {GOLD}Dongfeng 5 Diesel Locomotive ,{BLACK}全称：{GOLD}东风5型内燃机车
+STR_FULL_NAME_DF5KZ,"{BLACK}FULLNAME: {GOLD}Dongfeng 5 Diesel Locomotive ",{BLACK}全称：{GOLD}东风5型内燃机车
 STR_FULL_NAME_DF5,{BLACK}FULLNAME: {GOLD}Dongfeng 5 Diesel Locomotive 1000 Series,{BLACK}全称：{GOLD}东风5型内燃机车1000系
 STR_FULL_NAME_DF7G,{BLACK}FULLNAME: {GOLD}Dongfeng 7G Diesel Locomotive,{BLACK}全称：{GOLD}东风7G型内燃机车
 STR_FULL_NAME_DF7G5000,{BLACK}FULLNAME: {GOLD}Dongfeng 7G Diesel Locomotive 5000 Series,{BLACK}全称：{GOLD}东风7G型内燃机车5000系
@@ -421,7 +421,7 @@ STR_S25BLD_SERIES,Type S25B Series Coaches (Low-Door),S25B型双层客车 (低�
 STR_S25BHD_SERIES,Type S25B Series Coaches (High-Door),S25B型双层客车 (高开门)
 STR_25G_SERIES,Type 25G Series Coaches,25G型客车
 STR_25Z_SERIES,Type 25Z Series Coaches,25Z型客车
-STR_S25Z_SERIES,Type S25Z Series Coaches ,S25Z型双层客车
+STR_S25Z_SERIES,"Type S25Z Series Coaches ",S25Z型双层客车
 STR_25K_SERIES,Type 25K Series Coaches,25K型客车
 STR_S25KLD_SERIES,Type S25K Series Coaches (Low-Door),S25K型双层客车 (低开门)
 STR_S25KHD_SERIES,Type S25K Series Coaches (High-Door),S25K型双层客车 (高开门)
@@ -446,7 +446,7 @@ STR_DESC_2,{STRING}{}{STRING},
 # Desc,,
 STR_JINLUN_25DT,"Coaches use for DMU {BLUE}""JIN{WHITE}LUN""",{BLUE}金{WHITE}轮{RED}号{GOLD}内燃动车组所使用的拖车
 STR_XL25T_SSPE_DESCRIPTION,"{BLACK}A version of XL25T for Super Speed Parcel Express Co., Ltd.",{BLACK}新时速运递公司使用的XL25T版本。
-STR_CHA1C_DESC," {BLACK}Hybrid Locomotive. Use battery in non-electrifield railways as {BLUE}2000kw{BLACK},  and running as {RED}2400kw{BLACK} in 25kV AC railways", {BLACK}混合动力机车。在非电气化路段使用电池供电，功率为{BLUE}2000kw{BLACK}。在25kV交流供电铁路上功率为{RED}2400kw
+STR_CHA1C_DESC," {BLACK}Hybrid Locomotive using battery on non-electrified tracks providing {BLUE}2000 kW{BLACK}, and providing {RED}2400 kW{BLACK} on 25kV AC tracks"," {BLACK}混合动力机车。在非电气化路段使用电池供电，功率为{BLUE}2000 kW{BLACK}。在25kV交流供电铁路上功率为{RED}2400 kW"
 # Livery Availability,,
 STR_DF_LIVERY_AVAILABILITY,"{BLACK}Livery Availability: {GOLD}Yellow {GREEN}Line {BLACK}Livery, {WHITE}White {GREEN}Line {BLACK}Livery","{BLACK}可供选择的涂装：{GOLD}黄色{GREEN}窗线{BLACK}涂装, {WHITE}白色{GREEN}窗线{BLACK}涂装"
 STR_DF4_LIVERY_AVAILABILITY,"{BLACK}Livery Availability: {GREEN}Green {GOLD}Livery, {ORANGE}Orange {GOLD}Livery, {BLUE}Blue-{DKGREEN}-Green {BLACK}Livery (used in North Korea, DF4B only),{BLUE}Blue {GOLD}and {YELLOW}Yellow {GOLD}Livery, Jinhua-Wenzhou Livery (DF4B only)",{BLACK}可供选择的涂装：{GREEN}绿色涂装{GOLD}，{ORANGE}橘色涂装{BLACK}，{BLUE}“乌克兰”{YELLOW}涂装，使用于朝鲜的{BLUE}蓝{DKGREEN}绿{BLACK}色涂装，{WHITE}金{RED}温{BLUE}铁{WHITE}路{GOLD}涂装{DKGREEN}
@@ -493,9 +493,9 @@ STR_S25KHD_LIVERY_AVAILABILITY,"{BLACK}Livery Availability: {GOLD}Xianxing (Pion
 STR_SCA25KHD_LIVERY_AVAILABILITY,{BLACK}Livery Availability: {GOLD}Xi'an,{BLACK}可供选择的涂装：{GOLD}西安铁路局
 STR_TZ_LIVERY_AVAILABILITY,"{BLACK}Livery Availability: {ORANGE}Orange {GOLD}Livery, {GOLD}Beijing-Shanghai Direct Express {CREAM}Cream-{BROWN}-Brown {GOLD}Livery",{BLACK}可供选择的涂装：{ORANGE}橙色{GOLD}涂装，{GOLD}京沪直达特快{CREAM}奶油色-{BROWN}-棕红色{GOLD}涂装
 STR_KD25K_LIVERY_AVAILABILITY,"{BLACK}Livery Availability: {BLUE}Blue-{RED}Red{WHITE}-White {GOLD}Livery, {LTBLUE}Shanghai-Luchaogang {GOLD}Livery, Xi'an Livery, {DKGREEN}""Gaozu Green"" {GOLD}Livery (unfinished)",{BLACK}可供选择的涂装：{BLUE}蓝{WHITE}白{RED}红{GOLD}相间涂装，{LTBLUE}沪芦列车{GOLD}涂装，西安铁路局涂装，{DKGREEN}“高阻绿”{GOLD}涂装 (未完成)
-STR_25DT_JINLUN_LIVERY_AVAILABILITY,"{BLACK}Livery Availability: {GOLD}Earlier Livery (Before 2010), Later Livery (After 2010)", {GOLD}早期涂装 (2010年之前)，晚期涂装(2010年以后)
+STR_25DT_JINLUN_LIVERY_AVAILABILITY,"{BLACK}Livery Availability: {GOLD}Earlier Livery (Before 2010), Later Livery (After 2010)"," {GOLD}早期涂装 (2010年之前)，晚期涂装(2010年以后)"
 STR_YZ31_LIVERY_AVAILABILITY,"{BLACK}Livery Availability: {GOLD}Ordinary {GREEN}Green {GOLD}Livery, Sanshui-Maoming Railway Livery (unfinished)",{BLACK}可供选择的涂装：{GREEN}绿皮车{GOLD}涂装，三茂铁路涂装 (未完成)
-STR_25ML_LIVERY_AVAILABILITY,"{BLACK}Livery Availability: {WHITE}White-{GREEN}-Green {GOLD}Livery, {RED}RED-{GREEN}-Green {GOLD}Livery (after 2003)", {GOLD}白底绿带涂装，类25G红色涂装 (2003年以后)
+STR_25ML_LIVERY_AVAILABILITY,"{BLACK}Livery Availability: {WHITE}White-{GREEN}-Green {GOLD}Livery, {RED}RED-{GREEN}-Green {GOLD}Livery (after 2003)"," {GOLD}白底绿带涂装，类25G红色涂装 (2003年以后)"
 STR_G17_LIVERY_AVAILABILITY,{BLACK}Livery Availability: {BLACK}Black {GOLD}with Random-Colour Stripes (unfinished),{BLACK}可供选择的涂装：{GRAY}黑色{GOLD}加随机颜色条带 (未完成)
 STR_G60_LIVERY_AVAILABILITY,{BLACK}Livery Availability: {GRAY}Grey {GOLD}with Random-Colour Stripes (unfinished),{BLACK}可供选择的涂装：{GRAY}灰色{GOLD}加随机颜色条带 (未完成)
 STR_GN70_LIVERY_AVAILABILITY,{BLACK}Livery Availability: {BLACK}Black {GOLD}with Random-Colour Stripes (unfinished),{BLACK}可供选择的涂装：{BLACK}黑色{GOLD}加随机颜色条带 (未完成)
@@ -553,10 +553,10 @@ STR_HXD3D_NICKNAME,{BLACK}Nickname: {GOLD}Tomato,{BLACK}昵称： {GOLD}番茄
 STR_NDJ3_NICKNAME,{BLACK}Nickname: {WHITE}White Pig,{BLACK}昵称：{WHITE}大白猪
 STR_CR200J_NICKNAME,"{BLACK}Nickname: {GREEN}""Hulk"" {GOLD}(Official), {GREEN}""Trash Bin"" {GOLD}(Folk)",{BLACK}昵称：{GREEN}“绿巨人”{GOLD}(官方)，{GREEN}“垃圾桶”{GOLD}(民间)
 STR_CR200JC_NICKNAME,"{BLACK}Nickname: {GREEN}""AD Bin"" {GOLD}(Folk)",{BLACK}昵称：{RED}“A{WHITE}D{GREEN}桶”{GOLD}(民间)
-STR_CRH1A_NICKNAME,{BLACK}Nickname: {GOLD}Metro ,{BLACK}昵称：{GOLD}地铁
-STR_CRH1B_NICKNAME,{BLACK}Nickname: {GOLD}Long Metro ,{BLACK}昵称：{GOLD}长地铁
-STR_CRH1E_NICKNAME,{BLACK}Nickname: {GOLD}Sleeping Metro ,{BLACK}昵称：{GOLD}睡地铁
-STR_CRH1AA_NICKNAME,{BLACK}Nickname: {GOLD}Cute Metro ,{BLACK}昵称：{GOLD}萌地铁
+STR_CRH1A_NICKNAME,"{BLACK}Nickname: {GOLD}Metro ",{BLACK}昵称：{GOLD}地铁
+STR_CRH1B_NICKNAME,"{BLACK}Nickname: {GOLD}Long Metro ",{BLACK}昵称：{GOLD}长地铁
+STR_CRH1E_NICKNAME,"{BLACK}Nickname: {GOLD}Sleeping Metro ",{BLACK}昵称：{GOLD}睡地铁
+STR_CRH1AA_NICKNAME,"{BLACK}Nickname: {GOLD}Cute Metro ",{BLACK}昵称：{GOLD}萌地铁
 STR_CRH2A_NICKNAME,{BLACK}Nickname: {GOLD}Hairtail,{BLACK}昵称：{GOLD}带鱼
 STR_CRH2B_NICKNAME,{BLACK}Nickname: {GOLD}Long Hairtail,{BLACK}昵称：{GOLD}长带鱼
 STR_CRH2C_NICKNAME,{BLACK}Nickname: {GOLD}Crazy Hairtail,{BLACK}昵称：{GOLD}疯带鱼
@@ -582,27 +582,20 @@ STR_ALIASNAME_DF,{BLACK}Alias Name: {GOLD}Great Loong,{BLACK}曾用名：{GOLD}�
 STR_ALIASNME_SS1,{BLACK}Alias Name: {GOLD}6Y1,{BLACK}曾用名：{GOLD}6Y1
 STR_ALIASNAME_FXD1B,{BLACK}Alias Name: {GOLD}HXD1F (Hexie/Harmony 1F Electric Locomotive),{BLACK}曾用名：{GOLD}HXD1F(和谐1F型电力机车)
 # Reliability,,
-STR_RELIABILITY_32,{BLACK}Reliability decay speed: {GOLD}32,{BLACK}可靠性下降速度：{GOLD}32
-STR_RELIABILITY_24,{BLACK}Reliability decay speed: {GOLD}24,{BLACK}可靠性下降速度：{GOLD}24
-STR_RELIABILITY_20,{BLACK}Reliability decay speed: {GOLD}20,{BLACK}可靠性下降速度：{GOLD}20
-STR_RELIABILITY_16,{BLACK}Reliability decay speed: {GOLD}16,{BLACK}可靠性下降速度：{GOLD}16
-STR_RELIABILITY_15,{BLACK}Reliability decay speed: {GOLD}15,{BLACK}可靠性下降速度：{GOLD}15
-STR_RELIABILITY_14,{BLACK}Reliability decay speed: {GOLD}14,{BLACK}可靠性下降速度：{GOLD}14
-STR_RELIABILITY_12,{BLACK}Reliability decay speed: {GOLD}12,{BLACK}可靠性下降速度：{GOLD}12
-STR_RELIABILITY_10,{BLACK}Reliability decay speed: {GOLD}10,{BLACK}可靠性下降速度：{GOLD}10
-STR_RELIABILITY_8,{BLACK}Reliability decay speed: {GOLD}8,{BLACK}可靠性下降速度：{GOLD}8
-STR_RELIABILITY_6,{BLACK}Reliability decay speed: {GOLD}6,{BLACK}可靠性下降速度：{GOLD}6
-STR_RELIABILITY_5,{BLACK}Reliability decay speed: {GOLD}5,{BLACK}可靠性下降速度：{GOLD}5
-STR_RELIABILITY_3,{BLACK}Reliability decay speed: {GOLD}3,{BLACK}可靠性下降速度：{GOLD}3
+STR_RELDEC_VERY_HIGH,{BLACK}Reliability decay speed: {RED}Very high ({COMMA}),{BLACK}可靠性下降速度：{RED}极高（{COMMA}）
+STR_RELDEC_HIGH,{BLACK}Reliability decay speed: {ORANGE}High ({COMMA}),{BLACK}可靠性下降速度：{ORANGE}较高（{COMMA}）
+STR_RELDEC_MEDIUM,{BLACK}Reliability decay speed: {YELLOW}Medium ({COMMA}),{BLACK}可靠性下降速度：{YELLOW}一般（{COMMA}）
+STR_RELDEC_LOW,{BLACK}Reliability decay speed: {GREEN}Low ({COMMA}),{BLACK}可靠性下降速度：{GREEN}较低（{COMMA}）
+STR_RELDEC_VERY_LOW,{BLACK}Reliability decay speed: {BLUE}Very low ({COMMA}),{BLACK}可靠性下降速度：{BLUE}极低（{COMMA}）
 # Speed,,
-STR_310_KMH, - Max Speed 310 km/h, - 最高速度 310 km/h
-STR_350_KMH," - Max Speed 350 km/h, Running Costs Increase", - 最高速度 350 km/h，运营费用增加
-STR_380_KMH," - Max Speed 380 km/h, Running Costs Greatly Increase", - 最高速度 380 km/h，运营费用大幅增加
+STR_310_KMH," - Max Speed 310 km/h"," - 最高速度 310 km/h"
+STR_350_KMH," - Max Speed 350 km/h, Running Costs Increase"," - 最高速度 350 km/h，运营费用增加"
+STR_380_KMH," - Max Speed 380 km/h, Running Costs Greatly Increase"," - 最高速度 380 km/h，运营费用大幅增加"
 STR_350_AVAILABLE,Refittable to Max Speed 350 km/h (Increasing running costs),可改装为最高速度 350 km/h，运营费用增加
 STR_350_380_AVAILABLE,Refittable to Max Speed 350 or 380 km/h (Increasing running costs),可改装为最高速度 350 或 380 km/h，运营费用增加
 # Livery,,
-STR_ORIGINAL, - Original Livery, - 原版涂装
-STR_REVERSE, └ the Reverse of the Livery Above, └ 翻转的涂装
+STR_ORIGINAL," - Original Livery"," - 原版涂装"
+STR_REVERSE," └ the Reverse of the Livery Above"," └ 翻转的涂装"
 STR_ORANGE,{ORANGE} - Orange Livery,{ORANGE} - 橘色涂装
 STR_GREEN,{GREEN} - Green Livery,{GREEN} - 绿色涂装
 STR_RED,{RED} - Red Livery,{RED} - 红色涂装
@@ -611,103 +604,90 @@ STR_BLUE,{BLUE} - Blue Livery,{BLUE} - 蓝色涂装
 STR_GRASSGREEN,{DKGREEN} - Dark Green Livery,{DKGREEN} - 草绿色涂装
 STR_LATER_ORANGE,{ORANGE} - Later Orange Livery,{ORANGE} - 后期橘色涂装
 STR_LATER_GREEN,{GREEN} - Later Green Livery,{GREEN} - 后期绿色涂装
-STR_XIHU, - {GREEN}Xi'an{YELLOW}-{GREEN}Huxian {BLACK}Railway Livery, - {GREEN}西户铁路{BLACK}涂装
-STR_XIHU_REVERSE," - {GREEN}Xi'an{YELLOW}-{GREEN}Huxian {BLACK}Railway Livery, reversed", - {GREEN}西户铁路{BLACK}涂装，倒转方向
-STR_DF4D_7000, - {GREEN}7000-{YELLOW}Series {BLACK}Livery, - {GREEN}7000{YELLOW}系{BLACK}涂装
-STR_SS7C_BANANA, - {YELLOW}Banana Yellow {BLACK}Livery, - {YELLOW}黄色{BLACK}涂装
-STR_FUZHOU, - Fuzhou Livery, - 福州机务段涂装
-STR_UKRAINE, - {YELLOW}Yellow {BLACK}and {BLUE}Blue {BLACK}Livery, - {YELLOW}“乌克兰”{BLUE}涂装
-STR_DF4B_DPRK, - {BLUE}Blue-{DKGREEN}-Green {BLACK}Livery, - {BLUE}蓝{DKGREEN}绿{BLACK}相间涂装
-STR_DF4D4000_DPRK, - {BLUE}Blue-{DKGREEN}-Green {BLACK}Livery, - {BLUE}蓝{DKGREEN}绿{BLACK}相间涂装
-STR_DF4BN_ORIGINAL, - {BLUE}DF4B With New Bodyshell, - {BLUE}新头型DF4B
-STR_DF4BN_REVERSE, - {BLUE}DF4B With New Bodyshell (Reversed), - {BLUE}新头型DF4B (反转)
-STR_ALTERNATIVE, - Alternative Original Livery, - 另一种原版涂装
-STR_DF_YELLOW, - {GOLD}Yellow {GREEN}Line {BLACK}Livery, - {GOLD}黄色{GREEN}窗线{BLACK}涂装
-STR_DF_WHITE, - {WHITE}White {GREEN}Line {BLACK}Livery, - {WHITE}白色{GREEN}窗线{BLACK}涂装
-STR_FACTORY, - Factory Livery, - 出厂涂装
-STR_6Y2_LATE, - {GREEN}Late {BLACK}Livery, - {GREEN}晚期{BLACK}涂装
-STR_SS4_BLUEROOF, - {WHITE}White {BLACK}Livery with {BLUE}Blue{BLACK} Roof, - 白色涂装（车顶为{BLUE}蓝{BLACK}色）
-STR_SHENHUA, - {GOLD}Shenhua Groups Livery, - {GOLD}神华集团涂装
-STR_GUONENG, - {GOLD}CHN Energy Livery, - {GOLD}国家能源集团涂装
-STR_CHN2LAOS, - {GOLD}China-Laos Railway Livery, - {GOLD}中老铁路涂装
-STR_WUJING," - {GOLD}""Armed Police""Livery", - {GOLD}“武警”涂装
-STR_DFH7, - DFH7,
-STR_DFH7B, - DFH7B,
-STR_RANDOM_COLOR, - Ramdom Color, - 随机颜色
-STR_BUILD_YEAR, - According to build year, - 根据建造年份选择设计
-STR_YW22_ORIGINAL," - Original Design {RED}(Crowded) {BLACK}- Capacity 77, Comfort 240", - 初始设计 {RED}(拥挤) {BLACK}- 定员77，舒适度240
-STR_YW22_1966," - 1966 Design - Capacity 60, Comfort 288", - 1966年新设计 - 定员60，舒适度288
-STR_ORDINARY_GREEN, - {GREEN}Ordinary Green {BLACK}Livery, - {GREEN}绿皮车{BLACK}涂装
-STR_RED_WHITE, - {RED}Red {BLACK}and {WHITE}White, - {RED}红{WHITE}白{BLACK}相间
-STR_BLUE_RED_WHITE, - {BLUE}Blue-{RED}Red{WHITE}-White, - {BLUE}蓝{WHITE}白{RED}红{BLACK}相间涂装
-STR_JITONG, - {BLUE}Ji'ning{RED}-{WHITE}Tongliao {BLUE}Railway {BLACK}Livery, - {BLUE}集{RED}通{WHITE}铁{BLUE}路{BLACK}涂装
-STR_LUCHAOGANG, - {LTBLUE}Shanghai-Luchaogang {BLACK}Livery, - {LTBLUE}沪芦列车{BLACK}涂装
-STR_LIAODONG, - Liaodong Peninsula Livery, - 辽东半岛号涂装
-STR_DETERIORATE, - Deteriorated Livery, - 老化后
-STR_STRENGTHEN, - With Strengthening Steel Sheet, - 带加强筋
-STR_URUMQI, - Urumqi Railway Bureau, - 乌鲁木齐铁路局
-STR_XIAN, - Xi'an Railway Bureau, - 西安铁路局
-STR_SHENYANG, - Shenyang Railway Bureau, - 沈阳铁路局
-STR_XIANXING, - Xianxing (Pioneer) Livery, - 先行号涂装
-STR_XIZI, - Xizi Livery, - 西子号涂装
-STR_QINGZANG, - Qinghai-Tibet Railway Livery, - 青藏铁路涂装
-STR_GUANGSHEN, - Guangzhou-Shenzhen Railway Livery, - 广深铁路涂装
-STR_JINWEN, - {WHITE}Jinhua{RED}-{BLUE}Wenzhou {WHITE}Railway {BLACK}Company, - {WHITE}金{RED}温{BLUE}铁{WHITE}路{BLACK}公司
+STR_XIHU," - {GREEN}Xi'an{YELLOW}-{GREEN}Huxian {BLACK}Railway Livery"," - {GREEN}西户铁路{BLACK}涂装"
+STR_XIHU_REVERSE," - {GREEN}Xi'an{YELLOW}-{GREEN}Huxian {BLACK}Railway Livery, reversed"," - {GREEN}西户铁路{BLACK}涂装，倒转方向"
+STR_DF4D_7000," - {GREEN}7000-{YELLOW}Series {BLACK}Livery"," - {GREEN}7000{YELLOW}系{BLACK}涂装"
+STR_SS7C_BANANA," - {YELLOW}Banana Yellow {BLACK}Livery"," - {YELLOW}黄色{BLACK}涂装"
+STR_FUZHOU," - Fuzhou Livery"," - 福州机务段涂装"
+STR_UKRAINE," - {YELLOW}Yellow {BLACK}and {BLUE}Blue {BLACK}Livery"," - {YELLOW}“乌克兰”{BLUE}涂装"
+STR_DF4B_DPRK," - {BLUE}Blue-{DKGREEN}-Green {BLACK}Livery"," - {BLUE}蓝{DKGREEN}绿{BLACK}相间涂装"
+STR_DF4D4000_DPRK," - {BLUE}Blue-{DKGREEN}-Green {BLACK}Livery"," - {BLUE}蓝{DKGREEN}绿{BLACK}相间涂装"
+STR_DF4BN_ORIGINAL," - {BLUE}DF4B With New Bodyshell"," - {BLUE}新头型DF4B"
+STR_DF4BN_REVERSE," - {BLUE}DF4B With New Bodyshell (Reversed)"," - {BLUE}新头型DF4B (反转)"
+STR_ALTERNATIVE," - Alternative Original Livery"," - 另一种原版涂装"
+STR_DF_YELLOW," - {GOLD}Yellow {GREEN}Line {BLACK}Livery"," - {GOLD}黄色{GREEN}窗线{BLACK}涂装"
+STR_DF_WHITE," - {WHITE}White {GREEN}Line {BLACK}Livery"," - {WHITE}白色{GREEN}窗线{BLACK}涂装"
+STR_FACTORY," - Factory Livery"," - 出厂涂装"
+STR_6Y2_LATE," - {GREEN}Late {BLACK}Livery"," - {GREEN}晚期{BLACK}涂装"
+STR_SS4_BLUEROOF," - {WHITE}White {BLACK}Livery with {BLUE}Blue{BLACK} Roof"," - 白色涂装（车顶为{BLUE}蓝{BLACK}色）"
+STR_SHENHUA," - {GOLD}Shenhua Groups Livery"," - {GOLD}神华集团涂装"
+STR_GUONENG," - {GOLD}CHN Energy Livery"," - {GOLD}国家能源集团涂装"
+STR_CHN2LAOS," - {GOLD}China-Laos Railway Livery"," - {GOLD}中老铁路涂装"
+STR_WUJING," - {GOLD}""Armed Police""Livery"," - {GOLD}“武警”涂装"
+STR_DFH7," - DFH7",
+STR_DFH7B," - DFH7B",
+STR_RANDOM_COLOR," - Ramdom Color"," - 随机颜色"
+STR_BUILD_YEAR," - According to build year"," - 根据建造年份选择设计"
+STR_YW22_ORIGINAL," - Original Design {RED}(Crowded) {BLACK}- Capacity 77, Comfort 240"," - 初始设计 {RED}(拥挤) {BLACK}- 定员77，舒适度240"
+STR_YW22_1966," - 1966 Design - Capacity 60, Comfort 288"," - 1966年新设计 - 定员60，舒适度288"
+STR_ORDINARY_GREEN," - {GREEN}Ordinary Green {BLACK}Livery"," - {GREEN}绿皮车{BLACK}涂装"
+STR_RED_WHITE," - {RED}Red {BLACK}and {WHITE}White"," - {RED}红{WHITE}白{BLACK}相间"
+STR_BLUE_RED_WHITE," - {BLUE}Blue-{RED}Red{WHITE}-White"," - {BLUE}蓝{WHITE}白{RED}红{BLACK}相间涂装"
+STR_JITONG," - {BLUE}Ji'ning{RED}-{WHITE}Tongliao {BLUE}Railway {BLACK}Livery"," - {BLUE}集{RED}通{WHITE}铁{BLUE}路{BLACK}涂装"
+STR_LUCHAOGANG," - {LTBLUE}Shanghai-Luchaogang {BLACK}Livery"," - {LTBLUE}沪芦列车{BLACK}涂装"
+STR_LIAODONG," - Liaodong Peninsula Livery"," - 辽东半岛号涂装"
+STR_DETERIORATE," - Deteriorated Livery"," - 老化后"
+STR_STRENGTHEN," - With Strengthening Steel Sheet"," - 带加强筋"
+STR_URUMQI," - Urumqi Railway Bureau"," - 乌鲁木齐铁路局"
+STR_XIAN," - Xi'an Railway Bureau"," - 西安铁路局"
+STR_SHENYANG," - Shenyang Railway Bureau"," - 沈阳铁路局"
+STR_XIANXING," - Xianxing (Pioneer) Livery"," - 先行号涂装"
+STR_XIZI," - Xizi Livery"," - 西子号涂装"
+STR_QINGZANG," - Qinghai-Tibet Railway Livery"," - 青藏铁路涂装"
+STR_GUANGSHEN," - Guangzhou-Shenzhen Railway Livery"," - 广深铁路涂装"
+STR_JINWEN," - {WHITE}Jinhua{RED}-{BLUE}Wenzhou {WHITE}Railway {BLACK}Company"," - {WHITE}金{RED}温{BLUE}铁{WHITE}路{BLACK}公司"
 STR_GAOZU_GREEN," - {DKGREEN}""Gaozu Green"" {BLACK}(unfinished except 25T)"," - {DKGREEN}""高阻绿"" {BLACK}(未完成, 25T除外)"
-STR_BEIJING, - Beijing Railway Bureau, - 北京铁路局
-STR_WRU, - Wuhan Railway Vocational College of Technology Livery, - 武汉铁路技术学院涂装
-STR_BEIJING2SHANGHAI, - Beijing-Shanghai Express Train Livery {CREAM}Cream-{BROWN}-Brown, - 北京至上海13/14次直快涂装
-STR_LATER, - Later Livery, - 后期涂装
-STR_EARLIER, - Earlier Livery, - 早期涂装
-STR_LONGQINGXIA," - ""Longqingxia"" Livery", - 龙庆峡号涂装
-STR_BEIJING2SHANGHAIALT, - Beijing-Shanghai Express Train Livery {BLUE}Blue-{WHITE}-White, - 北京至上海21/22次直快涂装
-STR_RESCUE, - Wrecker Livery, - 救援涂装
-STR_BSP25T, - Made by BSP, - BSP制造
-STR_PROTOTYPE, - Prototype, - 原型
-STR_JINGTONG, - Beijing-Tongzhou Livery, - 京通号涂装
-STR_TIANFU, - Tianfu (Chengdu) Livery, - 成都天府号涂装
-STR_TIANFU_GREEN, - Tianfu (Chengdu) Livery with green stripes, - 成都天府号涂装，带绿色条带
-STR_GUANGZHU, - Guangzhou-Zhuhai Livery, - 广珠城际涂装
-STR_ZHENGJIAO, - Zhengzhou-Jiaozuo Livery, - 郑焦城际涂装
-STR_ZHUJI, - Zhuhai-Airport Livery, - 珠机城际涂装
-STR_ZHUSANJIAO_BLUE," - Pearl River Delta Intercity Railway, Blue", - 珠三角城际涂装(蓝)
-STR_ZHUSANJIAO_ORANGE," - Pearl River Delta Intercity Railway, Orange", - 珠三角城际涂装(橙)
-STR_JINSHAN, - Shanghai-Jinshan Livery, - 金山铁路涂装
-STR_GUANGQING, - Guangzhou-Qingyuan Livery, - 广清城际涂装
-STR_FOSHAN, - Foshan Livery, - 佛肇城际涂装
-STR_XIAOYONG, - Xiaoshan/Hangzhou-Ningbo Livery, - 萧甬铁路涂装
-STR_ASIAGAME, - {PURPLE}The 19th Asian Games Hangzhou {BLACK}Livery," - {PURPLE}杭州亚运会""润泽江南""{BLACK}涂装"
-STR_WINTER_OLYMPIC, - {LTBLUE}The XXIV Olympic Winter Games {BLACK}Livery," - {LTBLUE}北京冬奥会""瑞雪迎春""{BLACK}涂装"
+STR_BEIJING," - Beijing Railway Bureau"," - 北京铁路局"
+STR_WRU," - Wuhan Railway Vocational College of Technology Livery"," - 武汉铁路技术学院涂装"
+STR_BEIJING2SHANGHAI," - Beijing-Shanghai Express Train Livery {CREAM}Cream-{BROWN}-Brown"," - 北京至上海13/14次直快涂装"
+STR_LATER," - Later Livery"," - 后期涂装"
+STR_EARLIER," - Earlier Livery"," - 早期涂装"
+STR_LONGQINGXIA," - ""Longqingxia"" Livery"," - 龙庆峡号涂装"
+STR_BEIJING2SHANGHAIALT," - Beijing-Shanghai Express Train Livery {BLUE}Blue-{WHITE}-White"," - 北京至上海21/22次直快涂装"
+STR_RESCUE," - Wrecker Livery"," - 救援涂装"
+STR_BSP25T," - Made by BSP"," - BSP制造"
+STR_PROTOTYPE," - Prototype"," - 原型"
+STR_JINGTONG," - Beijing-Tongzhou Livery"," - 京通号涂装"
+STR_TIANFU," - Tianfu (Chengdu) Livery"," - 成都天府号涂装"
+STR_TIANFU_GREEN," - Tianfu (Chengdu) Livery with green stripes"," - 成都天府号涂装，带绿色条带"
+STR_GUANGZHU," - Guangzhou-Zhuhai Livery"," - 广珠城际涂装"
+STR_ZHENGJIAO," - Zhengzhou-Jiaozuo Livery"," - 郑焦城际涂装"
+STR_ZHUJI," - Zhuhai-Airport Livery"," - 珠机城际涂装"
+STR_ZHUSANJIAO_BLUE," - Pearl River Delta Intercity Railway, Blue"," - 珠三角城际涂装(蓝)"
+STR_ZHUSANJIAO_ORANGE," - Pearl River Delta Intercity Railway, Orange"," - 珠三角城际涂装(橙)"
+STR_JINSHAN," - Shanghai-Jinshan Livery"," - 金山铁路涂装"
+STR_GUANGQING," - Guangzhou-Qingyuan Livery"," - 广清城际涂装"
+STR_FOSHAN," - Foshan Livery"," - 佛肇城际涂装"
+STR_XIAOYONG," - Xiaoshan/Hangzhou-Ningbo Livery"," - 萧甬铁路涂装"
+STR_ASIAGAME," - {PURPLE}The 19th Asian Games Hangzhou {BLACK}Livery"," - {PURPLE}杭州亚运会""润泽江南""{BLACK}涂装"
+STR_WINTER_OLYMPIC," - {LTBLUE}The XXIV Olympic Winter Games {BLACK}Livery"," - {LTBLUE}北京冬奥会""瑞雪迎春""{BLACK}涂装"
 # Decay,,
-STR_COMFORT,{BLACK}Comfort: {GOLD}{COMMA},{BLACK}舒适度：{GOLD}{COMMA}
-STR_COMFORT_108,{BLACK}Comfort: {GOLD}108,{BLACK}舒适度：{GOLD}108
-STR_COMFORT_144,{BLACK}Comfort: {GOLD}144,{BLACK}舒适度：{GOLD}144
-STR_COMFORT_160,{BLACK}Comfort: {GOLD}160,{BLACK}舒适度：{GOLD}160
-STR_COMFORT_192,{BLACK}Comfort: {GOLD}192,{BLACK}舒适度：{GOLD}192
-STR_COMFORT_256,{BLACK}Comfort: {GOLD}256,{BLACK}舒适度：{GOLD}256
-STR_COMFORT_288,{BLACK}Comfort: {GOLD}288,{BLACK}舒适度：{GOLD}288
-STR_COMFORT_320,{BLACK}Comfort: {GOLD}320,{BLACK}舒适度：{GOLD}320
-STR_COMFORT_384,{BLACK}Comfort: {GOLD}384,{BLACK}舒适度：{GOLD}384
-STR_COMFORT_144_CAFE,"{BLACK}Comfort: {GOLD}144 {BLACK}, but at least 180 in operation due to its restaurant identity",{BLACK}舒适度：{GOLD}144{BLACK}，但由于餐车作用，运营时至少为180
-STR_COMFORT_160_CAFE,"{BLACK}Comfort: {GOLD}160 {BLACK}, but at least 200 in operation due to its restaurant identity",{BLACK}舒适度：{GOLD}160{BLACK}，但由于餐车作用，运营时至少为200
-STR_COMFORT_192_CAFE,"{BLACK}Comfort: {GOLD}192 {BLACK}, but at least 240 in operation due to its restaurant identity",{BLACK}舒适度：{GOLD}192{BLACK}，但由于餐车作用，运营时至少为240
-STR_COMFORT_384_AC,"{BLACK}Comfort: {GOLD}384 {BLACK}, but at least 480 in operation due to the presence of air conditioner",{BLACK}舒适度：{GOLD}384{BLACK}，但由于空调作用，运营时至少为480
-STR_COMFORT_240,{BLACK}Comfort: {GOLD}240,{BLACK}舒适度：{GOLD}240
-STR_COMFORT_400,{BLACK}Comfort: {GOLD}400,{BLACK}舒适度：{GOLD}400
-STR_COMFORT_480,{BLACK}Comfort: {GOLD}480,{BLACK}舒适度：{GOLD}480
-STR_COMFORT_640,{BLACK}Comfort: {GOLD}640,{BLACK}舒适度：{GOLD}640
-STR_COMFORT_720,{BLACK}Comfort: {GOLD}720,{BLACK}舒适度：{GOLD}720
-STR_COMFORT_800,{BLACK}Comfort: {GOLD}800,{BLACK}舒适度：{GOLD}800
-STR_COMFORT_240_CAFE,"{BLACK}Comfort: {GOLD}240 {BLACK}, but at least 300 in operation due to its restaurant identity",{BLACK}舒适度：{GOLD}240 {BLACK}，但由于餐车作用，运营时至少为300
-STR_DECAY_185,{BLACK}Cargo Age Period Factor {GOLD}185,{BLACK}货物贬值周期因子：{GOLD}185
-STR_DECAY_200,{BLACK}Cargo Age Period Factor {GOLD}200,{BLACK}货物贬值周期因子：{GOLD}200
-STR_DECAY_400,{BLACK}Cargo Age Period Factor {GOLD}400,{BLACK}货物贬值周期因子：{GOLD}400
-STR_DECAY_800,{BLACK}Cargo Age Period Factor {GOLD}800,{BLACK}货物贬值周期因子：{GOLD}800
-STR_DECAY_1600,{BLACK}Cargo Age Period Factor {GOLD}1600,{BLACK}货物贬值周期因子：{GOLD}1600
-STR_DECAY_BOXCAR,"{BLACK}Cargo Age Period Factor {GOLD}185, Passengers 80, Livestock 560",{BLACK}货物贬值周期因子：{GOLD}185，棚代客80，装载活禽/畜560
-STR_DECAY_BOXCAR_NOPASS,"{BLACK}Cargo Age Period Factor {GOLD}185, Livestock 560, Unrefittable to Passengers",{BLACK}货物贬值周期因子：{GOLD}185，装载活禽/畜560，棚代客不可用
+STR_COMFORT_VERY_LOW,{BLACK}Comfort: {RED}Very low ({COMMA}),{BLACK}舒适度：{RED}极低（{COMMA}）
+STR_COMFORT_LOW,{BLACK}Comfort: {ORANGE}Low ({COMMA}),{BLACK}舒适度：{ORANGE}较低（{COMMA}）
+STR_COMFORT_MEDIUM,{BLACK}Comfort: {YELLOW}Medium ({COMMA}),{BLACK}舒适度：{YELLOW}一般（{COMMA}）
+STR_COMFORT_HIGH,{BLACK}Comfort: {GREEN}High ({COMMA}),{BLACK}舒适度：{GREEN}较高（{COMMA}）
+STR_COMFORT_VERY_HIGH,{BLACK}Comfort: {BLUE}Very high ({COMMA}),{BLACK}舒适度：{BLUE}很高（{COMMA}）
+STR_COMFORT_EXTREMELY_HIGH,{BLACK}Comfort: {WHITE}Extremely high ({COMMA}),{BLACK}舒适度：{WHITE}极高（{COMMA}）
+STR_FRESHNESS_VERY_LOW,{BLACK}Cargo age period factor: {RED}Very low ({COMMA}),{BLACK}货物贬值周期因子：{RED}极低（{COMMA}）
+STR_FRESHNESS_LOW,{BLACK}Cargo age period factor: {ORANGE}Low ({COMMA}),{BLACK}货物贬值周期因子：{ORANGE}较低（{COMMA}）
+STR_FRESHNESS_MEDIUM,{BLACK}Cargo age period factor: {YELLOW}Medium ({COMMA}),{BLACK}货物贬值周期因子：{YELLOW}一般（{COMMA}）
+STR_FRESHNESS_HIGH,{BLACK}Cargo age period factor: {GREEN}High ({COMMA}),{BLACK}货物贬值周期因子：{GREEN}较高（{COMMA}）
+STR_FRESHNESS_VERY_HIGH,{BLACK}Cargo age period factor: {BLUE}Very high ({COMMA}),{BLACK}货物贬值周期因子：{BLUE}很高（{COMMA}）
+STR_FRESHNESS_EXTREMELY_HIGH,{BLACK}Cargo age period factor: {WHITE}Extremely High ({COMMA}),{BLACK}货物贬值周期因子：{WHITE}极高（{COMMA}）
+STR_DECAY_BOXCAR,"{BLACK}Cargo Age Period Factor: {YELLOW}185{BLACK}, Passengers {RED}80{BLACK}, Livestock {BLUE}560",{BLACK}货物贬值周期因子：{YELLOW}185{BLACK}，棚代客{RED}80{BLACK}，装载活禽/畜{BLUE}560
+STR_DECAY_BOXCAR_NOPASS,"{BLACK}Cargo Age Period Factor: {YELLOW}185{BLACK}, Livestock {BLUE}560{BLACK}, {RED}Unrefittable to Passengers",{BLACK}货物贬值周期因子：{YELLOW}185{BLACK}，装载活禽/畜{BLUE}560{BLACK}，棚代客{RED}不可用
 STR_CAFE_EFFECT,"{BLACK}Cafe Effect: {GOLD}Attaching Restaurant Car Halves Running Costs of Non-Commuter Passenger Cars except Restaurant Cars, and Increases Cargo Age Period by 1/4",{BLACK}餐车的作用：{GOLD}加挂餐车使除餐车外的所有非通勤客车运行费用减半，货物贬值周期增加1/4
-STR_AIR_CONDITIONER_EFFECT,{BLACK}Air Conditioner Effect: {GOLD}Attaching Air Conditioner Generator Car Increases Cargo Age Period of Most Passenger Cars Hauled by Locomotives without Electricity Supply,{BLACK}空调发电车的作用：{GOLD}加挂空调发电车可增加大部分非机供机车牵引客车的货物贬值周期
+STR_AIR_CONDITIONER_EFFECT,{BLACK}Air Conditioner Effect: {GOLD}Attaching Air Conditioner Generator Car Increases Cargo Age Period of Most Passenger Cars Hauled by Locomotives without Electricity Supply by 1/4,{BLACK}空调发电车的作用：{GOLD}加挂空调发电车可使大部分非机供机车牵引客车的货物贬值周期增加1/4
 STR_NO_AIR_CONDITIONER,{BLACK}Air Conditioner: {RED}Unavailable,{BLACK}空调：{RED}不可用
 STR_SELF_AIR_CONDITIONER,{BLACK}With Air Conditioner Compartment {RED}ONLY USED BY ITSELF,{BLACK}自带空调发电机{RED}但仅用于本车厢
 STR_DESC_PENGDAIKE,"{BLACK}Passengers in Boxcars (Peng Dai Ke): From 1980s to 2008, to handle huge traffic amounts during the Spring Festival period, temporary trains where passengers crowding in boxcars had to be operated. This reflected a severe lack of railway transport resources at that time.",{BLACK}棚代客：从20世纪80年代至2008年，为适应春运期间极大的客流量，部分铁路局曾开行使用棚车装载旅客的临客列车，内部极度拥挤。该现象反映了当时铁路运输资源的严重缺乏。
@@ -715,17 +695,17 @@ STR_DESC_PENGDAIKE,"{BLACK}Passengers in Boxcars (Peng Dai Ke): From 1980s to 20
 STR_ATTACH_ALL_CRH_CR,{BLACK}Matching MUs: {GOLD}All CRH (Hexie/Harmony) and CR (Fuxing/Revival) Series MUs,{BLACK}匹配的动车组：{GOLD}所有和谐/复兴号动车
 STR_ATTACH_SLEEPER_MU,{BLACK}Matching MUs: {GOLD}All CRH (Hexie/Harmony) and CR (Fuxing/Revival) Series Sleeper-Refit-Available MUs,{BLACK}匹配的动车组：{GOLD}所有提供卧铺的和谐/复兴号动车
 STR_ATTACH_CR200J,{BLACK}Matching MUs: {GOLD}CR200J Series,{BLACK}匹配的动车组：{GOLD}CR200J系列动车
-STR_NZJ1_XINSHUGUANG_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: {GOLD}ZE{BLACK}, equivalent to Double-Decker Hard Seat, Capacity: 136, Comfort: 200; {GOLD}ZY{BLACK}, equivalent to Double-Decker Soft Seat, Capacity: 108, Comfort: 240",{BLACK}匹配的车厢：{GOLD}二等座{BLACK}实为双层硬座，载客量：136，舒适度：200；{GOLD}一等座{BLACK}实为双层软座，载客量：108，舒适度：240
-STR_NDJ3_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: {GOLD}ZE, ZY, ZEC{BLACK}, Second Class Capacity: 114, Comfort: 200",{BLACK}匹配的车厢：{GOLD}二等座、一等座、二等/餐车合造{BLACK}，二等座载客量：114，舒适度：200
-STR_DJJ1_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: Only {GOLD}ZY{BLACK}, equivalent to Soft Seat, Comfort: 240",{BLACK}匹配的车厢：仅有{GOLD}一等座{BLACK}，与软座相似，舒适度：240
+STR_NZJ1_XINSHUGUANG_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: {GOLD}ZE{BLACK}, equivalent to Double-Decker Hard Seat, Capacity: 136, Comfort: {YELLOW}200{BLACK}; {GOLD}ZY{BLACK}, equivalent to Double-Decker Soft Seat, Capacity: 108, Comfort: {YELLOW}240",{BLACK}匹配的车厢：{GOLD}二等座{BLACK}实为双层硬座，载客量：136，舒适度：{YELLOW}200{BLACK}；{GOLD}一等座{BLACK}实为双层软座，载客量：108，舒适度：{YELLOW}240
+STR_NDJ3_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: {GOLD}ZE, ZY, ZEC{BLACK}, Second Class Capacity: 114, Comfort: {YELLOW}200",{BLACK}匹配的车厢：{GOLD}二等座、一等座、二等/餐车合造{BLACK}，二等座载客量：114，舒适度：{YELLOW}200
+STR_DJJ1_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: Only {GOLD}ZY{BLACK}, equivalent to Soft Seat, Comfort: {YELLOW}240",{BLACK}匹配的车厢：仅有{GOLD}一等座{BLACK}，与软座相似，舒适度：{YELLOW}240
 STR_CR200J_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: {GOLD}ZE, ZY, ZS, SW, ZEC, WE, WY, WG",{BLACK}匹配的车厢：{GOLD}二等座、一等座、商务座、商务座 (复兴号智能动车组标准) 、二等/餐车合造、二等卧、一等卧、高级软卧
 STR_CRH_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: {GOLD}ZE, ZY, ZS, SW, ZEC",{BLACK}匹配的车厢：{GOLD}二等座、一等座、商务座、商务座 (复兴号智能动车组标准) 、二等/餐车合造
 STR_CRH_SLEEPER_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: {GOLD}ZE, WY, WG, ZEC",{BLACK}匹配的车厢：{GOLD}二等座、一等卧、高级软卧、二等/餐车合造
 STR_CRH_LSLEEPER_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: {GOLD}WY, ZEC(As 1st-Class Sleeper with Restaurant Wagon)",{BLACK}匹配的车厢：{GOLD}一等卧、二等/餐车合造 (实为软卧/餐车合造车)
-STR_CRH6A2_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: {GOLD}ZE{BLACK} (with standing places, Comfort: 160), {GOLD}ZY",{BLACK}匹配的车厢：{GOLD}二等座{BLACK} (带站席，舒适度：160)、{GOLD}一等座
-STR_CRH6A3_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: Only {GOLD}ZE{BLACK}, with standing places, Comfort: 160",{BLACK}匹配的车厢：仅有{GOLD}二等座{BLACK}带站席，舒适度：160
-STR_CRH6F_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: Only {GOLD}ZE{BLACK}, with standing places (Crowded), Comfort: 120",{BLACK}匹配的车厢：仅有{GOLD}二等座{BLACK}带站席 (拥挤)，舒适度：120
-STR_NC3_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: Only {GOLD}ZE{BLACK}, Comfort: 185",{BLACK}匹配的车厢：仅有{GOLD}二等座{BLACK}，舒适度：185
+STR_CRH6A2_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: {GOLD}ZE{BLACK} (with standing places, Comfort: {ORANGE}160{BLACK}), {GOLD}ZY",{BLACK}匹配的车厢：{GOLD}二等座{BLACK} (带站席，舒适度：{ORANGE}160{BLACK})、{GOLD}一等座
+STR_CRH6A3_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: Only {GOLD}ZE{BLACK}, with standing places, Comfort: {ORANGE}160",{BLACK}匹配的车厢：仅有{GOLD}二等座{BLACK}带站席，舒适度：{ORANGE}160
+STR_CRH6F_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: Only {GOLD}ZE{BLACK}, with standing places (Crowded), Comfort: {RED}128",{BLACK}匹配的车厢：仅有{GOLD}二等座{BLACK}带站席 (拥挤)，舒适度：{RED}128
+STR_NC3_CAN_ATTACH_WAGON,"{BLACK}Matching Wagons: Only {GOLD}ZE{BLACK}, Comfort: 185",{BLACK}匹配的车厢：仅有{GOLD}二等座{BLACK}，舒适度：{YELLOW}185
 # Consist,,
 STR_NJ2_CONSIST,{BLACK}Consist: {GOLD}2 to 4 sections,{BLACK}构成：{GOLD}2-4节重联
 STR_HXN3QZ_CONSIST,{BLACK}Consist: {GOLD}2 to 4 sections,{BLACK}构成：{GOLD}2-4节重联
@@ -773,7 +753,7 @@ STR_CRH2B_HEAD_SEAT,{BLACK}Head Seat: {GOLD}2nd-Class (ZE),{BLACK}头车座席�
 STR_CRH2C_HEAD_SEAT,{BLACK}Head Seat: {GOLD}2nd-Class (ZE),{BLACK}头车座席：{GOLD}二等座
 STR_CRH2E_HEAD_SEAT,{BLACK}Head Seat: {GOLD}2nd-Class (ZE),{BLACK}头车座席：{GOLD}二等座
 STR_CRH2G_HEAD_SEAT,{BLACK}Head Seat: {GOLD}1st-Class (ZY),{BLACK}头车座席：{GOLD}一等座
-STR_CRH2ELS_HEAD_SEAT,{BLACK}Head Seat: {GOLD}1st-Class Sleeprt (WY),{BLACK}头车座席：{GOLD}动卧
+STR_CRH2ELS_HEAD_SEAT,{BLACK}Head Seat: {GOLD}1st-Class Sleeper (WY),{BLACK}头车座席：{GOLD}动卧
 STR_CRH3A_HEAD_SEAT,{BLACK}Head Seat: {GOLD}1st-Class (ZY),{BLACK}头车座席：{GOLD}一等座
 STR_CRH3C_HEAD_SEAT,{BLACK}Head Seat: {GOLD}2nd-Class (ZE),{BLACK}头车座席：{GOLD}二等座
 STR_CRH5A_HEAD_SEAT,{BLACK}Head Seat: {GOLD}1st-Class (ZY),{BLACK}头车座席：{GOLD}一等座
@@ -784,8 +764,8 @@ STR_CRH380D_HEAD_SEAT,{BLACK}Head Seat: {GOLD}1st-Class (ZY),{BLACK}头车座席
 STR_CR400_HEAD_SEAT,{BLACK}Head Seat: {GOLD}1st-Class (ZY),{BLACK}头车座席：{GOLD}一等座
 STR_CR400_Z_HEAD_SEAT,{BLACK}Head Seat: {GOLD}Luxury-Business-Class (SW),{BLACK}头车座席：{GOLD}商务座 (复兴号智能动车组标准)
 STR_CRH6A2_HEAD_SEAT,{BLACK}Head Seat: {GOLD}1st-Class (ZY),{BLACK}头车座席：{GOLD}一等座
-STR_CRH6A3_HEAD_SEAT,"{BLACK}Head Seat: {GOLD}2nd-Class (ZE){BLACK} with standing places, Comfort: 160",{BLACK}头车座席：{GOLD}二等座{BLACK}带站席，舒适度：160
-STR_CRH6F_HEAD_SEAT,"{BLACK}Head Seat: {GOLD}2nd-Class (ZE){BLACK} with standing places (crowded), Comfort: 140",{BLACK}头车座席：{GOLD}二等座{BLACK}带站席 (拥挤)，舒适度：140
+STR_CRH6A3_HEAD_SEAT,"{BLACK}Head Seat: {GOLD}2nd-Class (ZE){BLACK} with standing places, Comfort: {ORANGE}160",{BLACK}头车座席：{GOLD}二等座{BLACK}带站席，舒适度：{ORANGE}160
+STR_CRH6F_HEAD_SEAT,"{BLACK}Head Seat: {GOLD}2nd-Class (ZE){BLACK} with standing places (crowded), Comfort: {RED}128",{BLACK}头车座席：{GOLD}二等座{BLACK}带站席 (拥挤)，舒适度：{RED}128
 STR_CR300_HEAD_SEAT,{BLACK}Head Seat: {GOLD}1st-Class (ZY),{BLACK}头车座席：{GOLD}一等座
 STR_HEADSEAT_ZW,{BLACK}Head Seat: {GOLD}2nd-Class (ZE),
 STR_HEADSEAT_ZY,{BLACK}Head Seat: {GOLD}1st-Class (ZY),

--- a/lang/english.lng
+++ b/lang/english.lng
@@ -447,7 +447,7 @@ STR_DESC_2                                       :{STRING}{}{STRING}
 # Desc
 STR_JINLUN_25DT                                  :Coaches use for DMU {BLUE}"JIN{WHITE}LUN"
 STR_XL25T_SSPE_DESCRIPTION                       :{BLACK}A version of XL25T for Super Speed Parcel Express Co., Ltd.
-STR_CHA1C_DESC                                   : {BLACK}Hybrid Locomotive. Use battery in non-electrifield railways as {BLUE}2000kw{BLACK},  and running as {RED}2400kw{BLACK} in 25kV AC railways
+STR_CHA1C_DESC                                   : {BLACK}Hybrid Locomotive using battery on non-electrified tracks providing {BLUE}2000 kW{BLACK}, and providing {RED}2400 kW{BLACK} on 25kV AC tracks
 # Livery Availability
 STR_DF_LIVERY_AVAILABILITY                       :{BLACK}Livery Availability: {GOLD}Yellow {GREEN}Line {BLACK}Livery, {WHITE}White {GREEN}Line {BLACK}Livery
 STR_DF4_LIVERY_AVAILABILITY                      :{BLACK}Livery Availability: {GREEN}Green {GOLD}Livery, {ORANGE}Orange {GOLD}Livery, {BLUE}Blue-{DKGREEN}-Green {BLACK}Livery (used in North Korea, DF4B only),{BLUE}Blue {GOLD}and {YELLOW}Yellow {GOLD}Livery, Jinhua-Wenzhou Livery (DF4B only)
@@ -583,18 +583,11 @@ STR_ALIASNAME_DF                                 :{BLACK}Alias Name: {GOLD}Great
 STR_ALIASNME_SS1                                 :{BLACK}Alias Name: {GOLD}6Y1
 STR_ALIASNAME_FXD1B                              :{BLACK}Alias Name: {GOLD}HXD1F (Hexie/Harmony 1F Electric Locomotive)
 # Reliability
-STR_RELIABILITY_32                               :{BLACK}Reliability decay speed: {GOLD}32
-STR_RELIABILITY_24                               :{BLACK}Reliability decay speed: {GOLD}24
-STR_RELIABILITY_20                               :{BLACK}Reliability decay speed: {GOLD}20
-STR_RELIABILITY_16                               :{BLACK}Reliability decay speed: {GOLD}16
-STR_RELIABILITY_15                               :{BLACK}Reliability decay speed: {GOLD}15
-STR_RELIABILITY_14                               :{BLACK}Reliability decay speed: {GOLD}14
-STR_RELIABILITY_12                               :{BLACK}Reliability decay speed: {GOLD}12
-STR_RELIABILITY_10                               :{BLACK}Reliability decay speed: {GOLD}10
-STR_RELIABILITY_8                                :{BLACK}Reliability decay speed: {GOLD}8
-STR_RELIABILITY_6                                :{BLACK}Reliability decay speed: {GOLD}6
-STR_RELIABILITY_5                                :{BLACK}Reliability decay speed: {GOLD}5
-STR_RELIABILITY_3                                :{BLACK}Reliability decay speed: {GOLD}3
+STR_RELDEC_VERY_HIGH                             :{BLACK}Reliability decay speed: {RED}Very high ({COMMA})
+STR_RELDEC_HIGH                                  :{BLACK}Reliability decay speed: {ORANGE}High ({COMMA})
+STR_RELDEC_MEDIUM                                :{BLACK}Reliability decay speed: {YELLOW}Medium ({COMMA})
+STR_RELDEC_LOW                                   :{BLACK}Reliability decay speed: {GREEN}Low ({COMMA})
+STR_RELDEC_VERY_LOW                              :{BLACK}Reliability decay speed: {BLUE}Very low ({COMMA})
 # Speed
 STR_310_KMH                                      : - Max Speed 310 km/h
 STR_350_KMH                                      : - Max Speed 350 km/h, Running Costs Increase
@@ -680,35 +673,22 @@ STR_XIAOYONG                                     : - Xiaoshan/Hangzhou-Ningbo Li
 STR_ASIAGAME                                     : - {PURPLE}The 19th Asian Games Hangzhou {BLACK}Livery
 STR_WINTER_OLYMPIC                               : - {LTBLUE}The XXIV Olympic Winter Games {BLACK}Livery
 # Decay
-STR_COMFORT                                      :{BLACK}Comfort: {GOLD}{COMMA}
-STR_COMFORT_108                                  :{BLACK}Comfort: {GOLD}108
-STR_COMFORT_144                                  :{BLACK}Comfort: {GOLD}144
-STR_COMFORT_160                                  :{BLACK}Comfort: {GOLD}160
-STR_COMFORT_192                                  :{BLACK}Comfort: {GOLD}192
-STR_COMFORT_256                                  :{BLACK}Comfort: {GOLD}256
-STR_COMFORT_288                                  :{BLACK}Comfort: {GOLD}288
-STR_COMFORT_320                                  :{BLACK}Comfort: {GOLD}320
-STR_COMFORT_384                                  :{BLACK}Comfort: {GOLD}384
-STR_COMFORT_144_CAFE                             :{BLACK}Comfort: {GOLD}144 {BLACK}, but at least 180 in operation due to its restaurant identity
-STR_COMFORT_160_CAFE                             :{BLACK}Comfort: {GOLD}160 {BLACK}, but at least 200 in operation due to its restaurant identity
-STR_COMFORT_192_CAFE                             :{BLACK}Comfort: {GOLD}192 {BLACK}, but at least 240 in operation due to its restaurant identity
-STR_COMFORT_384_AC                               :{BLACK}Comfort: {GOLD}384 {BLACK}, but at least 480 in operation due to the presence of air conditioner
-STR_COMFORT_240                                  :{BLACK}Comfort: {GOLD}240
-STR_COMFORT_400                                  :{BLACK}Comfort: {GOLD}400
-STR_COMFORT_480                                  :{BLACK}Comfort: {GOLD}480
-STR_COMFORT_640                                  :{BLACK}Comfort: {GOLD}640
-STR_COMFORT_720                                  :{BLACK}Comfort: {GOLD}720
-STR_COMFORT_800                                  :{BLACK}Comfort: {GOLD}800
-STR_COMFORT_240_CAFE                             :{BLACK}Comfort: {GOLD}240 {BLACK}, but at least 300 in operation due to its restaurant identity
-STR_DECAY_185                                    :{BLACK}Cargo Age Period Factor {GOLD}185
-STR_DECAY_200                                    :{BLACK}Cargo Age Period Factor {GOLD}200
-STR_DECAY_400                                    :{BLACK}Cargo Age Period Factor {GOLD}400
-STR_DECAY_800                                    :{BLACK}Cargo Age Period Factor {GOLD}800
-STR_DECAY_1600                                   :{BLACK}Cargo Age Period Factor {GOLD}1600
-STR_DECAY_BOXCAR                                 :{BLACK}Cargo Age Period Factor {GOLD}185, Passengers 80, Livestock 560
-STR_DECAY_BOXCAR_NOPASS                          :{BLACK}Cargo Age Period Factor {GOLD}185, Livestock 560, Unrefittable to Passengers
+STR_COMFORT_VERY_LOW                             :{BLACK}Comfort: {RED}Very low ({COMMA})
+STR_COMFORT_LOW                                  :{BLACK}Comfort: {ORANGE}Low ({COMMA})
+STR_COMFORT_MEDIUM                               :{BLACK}Comfort: {YELLOW}Medium ({COMMA})
+STR_COMFORT_HIGH                                 :{BLACK}Comfort: {GREEN}High ({COMMA})
+STR_COMFORT_VERY_HIGH                            :{BLACK}Comfort: {BLUE}Very high ({COMMA})
+STR_COMFORT_EXTREMELY_HIGH                       :{BLACK}Comfort: {WHITE}Extremely high ({COMMA})
+STR_FRESHNESS_VERY_LOW                           :{BLACK}Cargo age period factor: {RED}Very low ({COMMA})
+STR_FRESHNESS_LOW                                :{BLACK}Cargo age period factor: {ORANGE}Low ({COMMA})
+STR_FRESHNESS_MEDIUM                             :{BLACK}Cargo age period factor: {YELLOW}Medium ({COMMA})
+STR_FRESHNESS_HIGH                               :{BLACK}Cargo age period factor: {GREEN}High ({COMMA})
+STR_FRESHNESS_VERY_HIGH                          :{BLACK}Cargo age period factor: {BLUE}Very high ({COMMA})
+STR_FRESHNESS_EXTREMELY_HIGH                     :{BLACK}Cargo age period factor: {WHITE}Extremely High ({COMMA})
+STR_DECAY_BOXCAR                                 :{BLACK}Cargo Age Period Factor: {YELLOW}185{BLACK}, Passengers {RED}80{BLACK}, Livestock {BLUE}560
+STR_DECAY_BOXCAR_NOPASS                          :{BLACK}Cargo Age Period Factor: {YELLOW}185{BLACK}, Livestock {BLUE}560{BLACK}, {RED}Unrefittable to Passengers
 STR_CAFE_EFFECT                                  :{BLACK}Cafe Effect: {GOLD}Attaching Restaurant Car Halves Running Costs of Non-Commuter Passenger Cars except Restaurant Cars, and Increases Cargo Age Period by 1/4
-STR_AIR_CONDITIONER_EFFECT                       :{BLACK}Air Conditioner Effect: {GOLD}Attaching Air Conditioner Generator Car Increases Cargo Age Period of Most Passenger Cars Hauled by Locomotives without Electricity Supply
+STR_AIR_CONDITIONER_EFFECT                       :{BLACK}Air Conditioner Effect: {GOLD}Attaching Air Conditioner Generator Car Increases Cargo Age Period of Most Passenger Cars Hauled by Locomotives without Electricity Supply by 1/4
 STR_NO_AIR_CONDITIONER                           :{BLACK}Air Conditioner: {RED}Unavailable
 STR_SELF_AIR_CONDITIONER                         :{BLACK}With Air Conditioner Compartment {RED}ONLY USED BY ITSELF
 STR_DESC_PENGDAIKE                               :{BLACK}Passengers in Boxcars (Peng Dai Ke): From 1980s to 2008, to handle huge traffic amounts during the Spring Festival period, temporary trains where passengers crowding in boxcars had to be operated. This reflected a severe lack of railway transport resources at that time.
@@ -716,16 +696,16 @@ STR_DESC_PENGDAIKE                               :{BLACK}Passengers in Boxcars (
 STR_ATTACH_ALL_CRH_CR                            :{BLACK}Matching MUs: {GOLD}All CRH (Hexie/Harmony) and CR (Fuxing/Revival) Series MUs
 STR_ATTACH_SLEEPER_MU                            :{BLACK}Matching MUs: {GOLD}All CRH (Hexie/Harmony) and CR (Fuxing/Revival) Series Sleeper-Refit-Available MUs
 STR_ATTACH_CR200J                                :{BLACK}Matching MUs: {GOLD}CR200J Series
-STR_NZJ1_XINSHUGUANG_CAN_ATTACH_WAGON            :{BLACK}Matching Wagons: {GOLD}ZE{BLACK}, equivalent to Double-Decker Hard Seat, Capacity: 136, Comfort: 200; {GOLD}ZY{BLACK}, equivalent to Double-Decker Soft Seat, Capacity: 108, Comfort: 240
-STR_NDJ3_CAN_ATTACH_WAGON                        :{BLACK}Matching Wagons: {GOLD}ZE, ZY, ZEC{BLACK}, Second Class Capacity: 114, Comfort: 200
-STR_DJJ1_CAN_ATTACH_WAGON                        :{BLACK}Matching Wagons: Only {GOLD}ZY{BLACK}, equivalent to Soft Seat, Comfort: 240
+STR_NZJ1_XINSHUGUANG_CAN_ATTACH_WAGON            :{BLACK}Matching Wagons: {GOLD}ZE{BLACK}, equivalent to Double-Decker Hard Seat, Capacity: 136, Comfort: {YELLOW}200{BLACK}; {GOLD}ZY{BLACK}, equivalent to Double-Decker Soft Seat, Capacity: 108, Comfort: {YELLOW}240
+STR_NDJ3_CAN_ATTACH_WAGON                        :{BLACK}Matching Wagons: {GOLD}ZE, ZY, ZEC{BLACK}, Second Class Capacity: 114, Comfort: {YELLOW}200
+STR_DJJ1_CAN_ATTACH_WAGON                        :{BLACK}Matching Wagons: Only {GOLD}ZY{BLACK}, equivalent to Soft Seat, Comfort: {YELLOW}240
 STR_CR200J_CAN_ATTACH_WAGON                      :{BLACK}Matching Wagons: {GOLD}ZE, ZY, ZS, SW, ZEC, WE, WY, WG
 STR_CRH_CAN_ATTACH_WAGON                         :{BLACK}Matching Wagons: {GOLD}ZE, ZY, ZS, SW, ZEC
 STR_CRH_SLEEPER_CAN_ATTACH_WAGON                 :{BLACK}Matching Wagons: {GOLD}ZE, WY, WG, ZEC
 STR_CRH_LSLEEPER_CAN_ATTACH_WAGON                :{BLACK}Matching Wagons: {GOLD}WY, ZEC(As 1st-Class Sleeper with Restaurant Wagon)
-STR_CRH6A2_CAN_ATTACH_WAGON                      :{BLACK}Matching Wagons: {GOLD}ZE{BLACK} (with standing places, Comfort: 160), {GOLD}ZY
-STR_CRH6A3_CAN_ATTACH_WAGON                      :{BLACK}Matching Wagons: Only {GOLD}ZE{BLACK}, with standing places, Comfort: 160
-STR_CRH6F_CAN_ATTACH_WAGON                       :{BLACK}Matching Wagons: Only {GOLD}ZE{BLACK}, with standing places (Crowded), Comfort: 120
+STR_CRH6A2_CAN_ATTACH_WAGON                      :{BLACK}Matching Wagons: {GOLD}ZE{BLACK} (with standing places, Comfort: {ORANGE}160{BLACK}), {GOLD}ZY
+STR_CRH6A3_CAN_ATTACH_WAGON                      :{BLACK}Matching Wagons: Only {GOLD}ZE{BLACK}, with standing places, Comfort: {ORANGE}160
+STR_CRH6F_CAN_ATTACH_WAGON                       :{BLACK}Matching Wagons: Only {GOLD}ZE{BLACK}, with standing places (Crowded), Comfort: {RED}128
 STR_NC3_CAN_ATTACH_WAGON                         :{BLACK}Matching Wagons: Only {GOLD}ZE{BLACK}, Comfort: 185
 # Consist
 STR_NJ2_CONSIST                                  :{BLACK}Consist: {GOLD}2 to 4 sections
@@ -774,7 +754,7 @@ STR_CRH2B_HEAD_SEAT                              :{BLACK}Head Seat: {GOLD}2nd-Cl
 STR_CRH2C_HEAD_SEAT                              :{BLACK}Head Seat: {GOLD}2nd-Class (ZE)
 STR_CRH2E_HEAD_SEAT                              :{BLACK}Head Seat: {GOLD}2nd-Class (ZE)
 STR_CRH2G_HEAD_SEAT                              :{BLACK}Head Seat: {GOLD}1st-Class (ZY)
-STR_CRH2ELS_HEAD_SEAT                            :{BLACK}Head Seat: {GOLD}1st-Class Sleeprt (WY)
+STR_CRH2ELS_HEAD_SEAT                            :{BLACK}Head Seat: {GOLD}1st-Class Sleeper (WY)
 STR_CRH3A_HEAD_SEAT                              :{BLACK}Head Seat: {GOLD}1st-Class (ZY)
 STR_CRH3C_HEAD_SEAT                              :{BLACK}Head Seat: {GOLD}2nd-Class (ZE)
 STR_CRH5A_HEAD_SEAT                              :{BLACK}Head Seat: {GOLD}1st-Class (ZY)
@@ -785,8 +765,8 @@ STR_CRH380D_HEAD_SEAT                            :{BLACK}Head Seat: {GOLD}1st-Cl
 STR_CR400_HEAD_SEAT                              :{BLACK}Head Seat: {GOLD}1st-Class (ZY)
 STR_CR400_Z_HEAD_SEAT                            :{BLACK}Head Seat: {GOLD}Luxury-Business-Class (SW)
 STR_CRH6A2_HEAD_SEAT                             :{BLACK}Head Seat: {GOLD}1st-Class (ZY)
-STR_CRH6A3_HEAD_SEAT                             :{BLACK}Head Seat: {GOLD}2nd-Class (ZE){BLACK} with standing places, Comfort: 160
-STR_CRH6F_HEAD_SEAT                              :{BLACK}Head Seat: {GOLD}2nd-Class (ZE){BLACK} with standing places (crowded), Comfort: 140
+STR_CRH6A3_HEAD_SEAT                             :{BLACK}Head Seat: {GOLD}2nd-Class (ZE){BLACK} with standing places, Comfort: {ORANGE}160
+STR_CRH6F_HEAD_SEAT                              :{BLACK}Head Seat: {GOLD}2nd-Class (ZE){BLACK} with standing places (crowded), Comfort: {RED}128
 STR_CR300_HEAD_SEAT                              :{BLACK}Head Seat: {GOLD}1st-Class (ZY)
 STR_HEADSEAT_ZW                                  :{BLACK}Head Seat: {GOLD}2nd-Class (ZE)
 STR_HEADSEAT_ZY                                  :{BLACK}Head Seat: {GOLD}1st-Class (ZY)

--- a/lang/simplified_chinese.lng
+++ b/lang/simplified_chinese.lng
@@ -433,7 +433,7 @@ STR_HU_IMPORT                                    :匈牙利进口车型
 # Desc
 STR_JINLUN_25DT                                  :{BLUE}金{WHITE}轮{RED}号{GOLD}内燃动车组所使用的拖车
 STR_XL25T_SSPE_DESCRIPTION                       :{BLACK}新时速运递公司使用的XL25T版本。
-STR_CHA1C_DESC                                   : {BLACK}混合动力机车。在非电气化路段使用电池供电，功率为{BLUE}2000kw{BLACK}。在25kV交流供电铁路上功率为{RED}2400kw
+STR_CHA1C_DESC                                   : {BLACK}混合动力机车。在非电气化路段使用电池供电，功率为{BLUE}2000 kW{BLACK}。在25kV交流供电铁路上功率为{RED}2400 kW
 # Livery Availability
 STR_DF_LIVERY_AVAILABILITY                       :{BLACK}可供选择的涂装：{GOLD}黄色{GREEN}窗线{BLACK}涂装, {WHITE}白色{GREEN}窗线{BLACK}涂装
 STR_DF4_LIVERY_AVAILABILITY                      :{BLACK}可供选择的涂装：{GREEN}绿色涂装{GOLD}，{ORANGE}橘色涂装{BLACK}，{BLUE}“乌克兰”{YELLOW}涂装，使用于朝鲜的{BLUE}蓝{DKGREEN}绿{BLACK}色涂装，{WHITE}金{RED}温{BLUE}铁{WHITE}路{GOLD}涂装{DKGREEN}
@@ -569,18 +569,11 @@ STR_ALIASNAME_DF                                 :{BLACK}曾用名：{GOLD}巨�
 STR_ALIASNME_SS1                                 :{BLACK}曾用名：{GOLD}6Y1
 STR_ALIASNAME_FXD1B                              :{BLACK}曾用名：{GOLD}HXD1F(和谐1F型电力机车)
 # Reliability
-STR_RELIABILITY_32                               :{BLACK}可靠性下降速度：{GOLD}32
-STR_RELIABILITY_24                               :{BLACK}可靠性下降速度：{GOLD}24
-STR_RELIABILITY_20                               :{BLACK}可靠性下降速度：{GOLD}20
-STR_RELIABILITY_16                               :{BLACK}可靠性下降速度：{GOLD}16
-STR_RELIABILITY_15                               :{BLACK}可靠性下降速度：{GOLD}15
-STR_RELIABILITY_14                               :{BLACK}可靠性下降速度：{GOLD}14
-STR_RELIABILITY_12                               :{BLACK}可靠性下降速度：{GOLD}12
-STR_RELIABILITY_10                               :{BLACK}可靠性下降速度：{GOLD}10
-STR_RELIABILITY_8                                :{BLACK}可靠性下降速度：{GOLD}8
-STR_RELIABILITY_6                                :{BLACK}可靠性下降速度：{GOLD}6
-STR_RELIABILITY_5                                :{BLACK}可靠性下降速度：{GOLD}5
-STR_RELIABILITY_3                                :{BLACK}可靠性下降速度：{GOLD}3
+STR_RELDEC_VERY_HIGH                             :{BLACK}可靠性下降速度：{RED}极高（{COMMA}）
+STR_RELDEC_HIGH                                  :{BLACK}可靠性下降速度：{ORANGE}较高（{COMMA}）
+STR_RELDEC_MEDIUM                                :{BLACK}可靠性下降速度：{YELLOW}一般（{COMMA}）
+STR_RELDEC_LOW                                   :{BLACK}可靠性下降速度：{GREEN}较低（{COMMA}）
+STR_RELDEC_VERY_LOW                              :{BLACK}可靠性下降速度：{BLUE}极低（{COMMA}）
 # Speed
 STR_310_KMH                                      : - 最高速度 310 km/h
 STR_350_KMH                                      : - 最高速度 350 km/h，运营费用增加
@@ -664,35 +657,22 @@ STR_XIAOYONG                                     : - 萧甬铁路涂装
 STR_ASIAGAME                                     : - {PURPLE}杭州亚运会"润泽江南"{BLACK}涂装
 STR_WINTER_OLYMPIC                               : - {LTBLUE}北京冬奥会"瑞雪迎春"{BLACK}涂装
 # Decay
-STR_COMFORT                                      :{BLACK}舒适度：{GOLD}{COMMA}
-STR_COMFORT_108                                  :{BLACK}舒适度：{GOLD}108
-STR_COMFORT_144                                  :{BLACK}舒适度：{GOLD}144
-STR_COMFORT_160                                  :{BLACK}舒适度：{GOLD}160
-STR_COMFORT_192                                  :{BLACK}舒适度：{GOLD}192
-STR_COMFORT_256                                  :{BLACK}舒适度：{GOLD}256
-STR_COMFORT_288                                  :{BLACK}舒适度：{GOLD}288
-STR_COMFORT_320                                  :{BLACK}舒适度：{GOLD}320
-STR_COMFORT_384                                  :{BLACK}舒适度：{GOLD}384
-STR_COMFORT_144_CAFE                             :{BLACK}舒适度：{GOLD}144{BLACK}，但由于餐车作用，运营时至少为180
-STR_COMFORT_160_CAFE                             :{BLACK}舒适度：{GOLD}160{BLACK}，但由于餐车作用，运营时至少为200
-STR_COMFORT_192_CAFE                             :{BLACK}舒适度：{GOLD}192{BLACK}，但由于餐车作用，运营时至少为240
-STR_COMFORT_384_AC                               :{BLACK}舒适度：{GOLD}384{BLACK}，但由于空调作用，运营时至少为480
-STR_COMFORT_240                                  :{BLACK}舒适度：{GOLD}240
-STR_COMFORT_400                                  :{BLACK}舒适度：{GOLD}400
-STR_COMFORT_480                                  :{BLACK}舒适度：{GOLD}480
-STR_COMFORT_640                                  :{BLACK}舒适度：{GOLD}640
-STR_COMFORT_720                                  :{BLACK}舒适度：{GOLD}720
-STR_COMFORT_800                                  :{BLACK}舒适度：{GOLD}800
-STR_COMFORT_240_CAFE                             :{BLACK}舒适度：{GOLD}240 {BLACK}，但由于餐车作用，运营时至少为300
-STR_DECAY_185                                    :{BLACK}货物贬值周期因子：{GOLD}185
-STR_DECAY_200                                    :{BLACK}货物贬值周期因子：{GOLD}200
-STR_DECAY_400                                    :{BLACK}货物贬值周期因子：{GOLD}400
-STR_DECAY_800                                    :{BLACK}货物贬值周期因子：{GOLD}800
-STR_DECAY_1600                                   :{BLACK}货物贬值周期因子：{GOLD}1600
-STR_DECAY_BOXCAR                                 :{BLACK}货物贬值周期因子：{GOLD}185，棚代客80，装载活禽/畜560
-STR_DECAY_BOXCAR_NOPASS                          :{BLACK}货物贬值周期因子：{GOLD}185，装载活禽/畜560，棚代客不可用
+STR_COMFORT_VERY_LOW                             :{BLACK}舒适度：{RED}极低（{COMMA}）
+STR_COMFORT_LOW                                  :{BLACK}舒适度：{ORANGE}较低（{COMMA}）
+STR_COMFORT_MEDIUM                               :{BLACK}舒适度：{YELLOW}一般（{COMMA}）
+STR_COMFORT_HIGH                                 :{BLACK}舒适度：{GREEN}较高（{COMMA}）
+STR_COMFORT_VERY_HIGH                            :{BLACK}舒适度：{BLUE}很高（{COMMA}）
+STR_COMFORT_EXTREMELY_HIGH                       :{BLACK}舒适度：{WHITE}极高（{COMMA}）
+STR_FRESHNESS_VERY_LOW                           :{BLACK}货物贬值周期因子：{RED}极低（{COMMA}）
+STR_FRESHNESS_LOW                                :{BLACK}货物贬值周期因子：{ORANGE}较低（{COMMA}）
+STR_FRESHNESS_MEDIUM                             :{BLACK}货物贬值周期因子：{YELLOW}一般（{COMMA}）
+STR_FRESHNESS_HIGH                               :{BLACK}货物贬值周期因子：{GREEN}较高（{COMMA}）
+STR_FRESHNESS_VERY_HIGH                          :{BLACK}货物贬值周期因子：{BLUE}很高（{COMMA}）
+STR_FRESHNESS_EXTREMELY_HIGH                     :{BLACK}货物贬值周期因子：{WHITE}极高（{COMMA}）
+STR_DECAY_BOXCAR                                 :{BLACK}货物贬值周期因子：{YELLOW}185{BLACK}，棚代客{RED}80{BLACK}，装载活禽/畜{BLUE}560
+STR_DECAY_BOXCAR_NOPASS                          :{BLACK}货物贬值周期因子：{YELLOW}185{BLACK}，装载活禽/畜{BLUE}560{BLACK}，棚代客{RED}不可用
 STR_CAFE_EFFECT                                  :{BLACK}餐车的作用：{GOLD}加挂餐车使除餐车外的所有非通勤客车运行费用减半，货物贬值周期增加1/4
-STR_AIR_CONDITIONER_EFFECT                       :{BLACK}空调发电车的作用：{GOLD}加挂空调发电车可增加大部分非机供机车牵引客车的货物贬值周期
+STR_AIR_CONDITIONER_EFFECT                       :{BLACK}空调发电车的作用：{GOLD}加挂空调发电车可使大部分非机供机车牵引客车的货物贬值周期增加1/4
 STR_NO_AIR_CONDITIONER                           :{BLACK}空调：{RED}不可用
 STR_SELF_AIR_CONDITIONER                         :{BLACK}自带空调发电机{RED}但仅用于本车厢
 STR_DESC_PENGDAIKE                               :{BLACK}棚代客：从20世纪80年代至2008年，为适应春运期间极大的客流量，部分铁路局曾开行使用棚车装载旅客的临客列车，内部极度拥挤。该现象反映了当时铁路运输资源的严重缺乏。
@@ -700,17 +680,17 @@ STR_DESC_PENGDAIKE                               :{BLACK}棚代客：从20世纪
 STR_ATTACH_ALL_CRH_CR                            :{BLACK}匹配的动车组：{GOLD}所有和谐/复兴号动车
 STR_ATTACH_SLEEPER_MU                            :{BLACK}匹配的动车组：{GOLD}所有提供卧铺的和谐/复兴号动车
 STR_ATTACH_CR200J                                :{BLACK}匹配的动车组：{GOLD}CR200J系列动车
-STR_NZJ1_XINSHUGUANG_CAN_ATTACH_WAGON            :{BLACK}匹配的车厢：{GOLD}二等座{BLACK}实为双层硬座，载客量：136，舒适度：200；{GOLD}一等座{BLACK}实为双层软座，载客量：108，舒适度：240
-STR_NDJ3_CAN_ATTACH_WAGON                        :{BLACK}匹配的车厢：{GOLD}二等座、一等座、二等/餐车合造{BLACK}，二等座载客量：114，舒适度：200
-STR_DJJ1_CAN_ATTACH_WAGON                        :{BLACK}匹配的车厢：仅有{GOLD}一等座{BLACK}，与软座相似，舒适度：240
+STR_NZJ1_XINSHUGUANG_CAN_ATTACH_WAGON            :{BLACK}匹配的车厢：{GOLD}二等座{BLACK}实为双层硬座，载客量：136，舒适度：{YELLOW}200{BLACK}；{GOLD}一等座{BLACK}实为双层软座，载客量：108，舒适度：{YELLOW}240
+STR_NDJ3_CAN_ATTACH_WAGON                        :{BLACK}匹配的车厢：{GOLD}二等座、一等座、二等/餐车合造{BLACK}，二等座载客量：114，舒适度：{YELLOW}200
+STR_DJJ1_CAN_ATTACH_WAGON                        :{BLACK}匹配的车厢：仅有{GOLD}一等座{BLACK}，与软座相似，舒适度：{YELLOW}240
 STR_CR200J_CAN_ATTACH_WAGON                      :{BLACK}匹配的车厢：{GOLD}二等座、一等座、商务座、商务座 (复兴号智能动车组标准) 、二等/餐车合造、二等卧、一等卧、高级软卧
 STR_CRH_CAN_ATTACH_WAGON                         :{BLACK}匹配的车厢：{GOLD}二等座、一等座、商务座、商务座 (复兴号智能动车组标准) 、二等/餐车合造
 STR_CRH_SLEEPER_CAN_ATTACH_WAGON                 :{BLACK}匹配的车厢：{GOLD}二等座、一等卧、高级软卧、二等/餐车合造
 STR_CRH_LSLEEPER_CAN_ATTACH_WAGON                :{BLACK}匹配的车厢：{GOLD}一等卧、二等/餐车合造 (实为软卧/餐车合造车)
-STR_CRH6A2_CAN_ATTACH_WAGON                      :{BLACK}匹配的车厢：{GOLD}二等座{BLACK} (带站席，舒适度：160)、{GOLD}一等座
-STR_CRH6A3_CAN_ATTACH_WAGON                      :{BLACK}匹配的车厢：仅有{GOLD}二等座{BLACK}带站席，舒适度：160
-STR_CRH6F_CAN_ATTACH_WAGON                       :{BLACK}匹配的车厢：仅有{GOLD}二等座{BLACK}带站席 (拥挤)，舒适度：120
-STR_NC3_CAN_ATTACH_WAGON                         :{BLACK}匹配的车厢：仅有{GOLD}二等座{BLACK}，舒适度：185
+STR_CRH6A2_CAN_ATTACH_WAGON                      :{BLACK}匹配的车厢：{GOLD}二等座{BLACK} (带站席，舒适度：{ORANGE}160{BLACK})、{GOLD}一等座
+STR_CRH6A3_CAN_ATTACH_WAGON                      :{BLACK}匹配的车厢：仅有{GOLD}二等座{BLACK}带站席，舒适度：{ORANGE}160
+STR_CRH6F_CAN_ATTACH_WAGON                       :{BLACK}匹配的车厢：仅有{GOLD}二等座{BLACK}带站席 (拥挤)，舒适度：{RED}128
+STR_NC3_CAN_ATTACH_WAGON                         :{BLACK}匹配的车厢：仅有{GOLD}二等座{BLACK}，舒适度：{YELLOW}185
 # Consist
 STR_NJ2_CONSIST                                  :{BLACK}构成：{GOLD}2-4节重联
 STR_HXN3QZ_CONSIST                               :{BLACK}构成：{GOLD}2-4节重联
@@ -767,8 +747,8 @@ STR_CRH380D_HEAD_SEAT                            :{BLACK}头车座席：{GOLD}�
 STR_CR400_HEAD_SEAT                              :{BLACK}头车座席：{GOLD}一等座
 STR_CR400_Z_HEAD_SEAT                            :{BLACK}头车座席：{GOLD}商务座 (复兴号智能动车组标准)
 STR_CRH6A2_HEAD_SEAT                             :{BLACK}头车座席：{GOLD}一等座
-STR_CRH6A3_HEAD_SEAT                             :{BLACK}头车座席：{GOLD}二等座{BLACK}带站席，舒适度：160
-STR_CRH6F_HEAD_SEAT                              :{BLACK}头车座席：{GOLD}二等座{BLACK}带站席 (拥挤)，舒适度：140
+STR_CRH6A3_HEAD_SEAT                             :{BLACK}头车座席：{GOLD}二等座{BLACK}带站席，舒适度：{ORANGE}160
+STR_CRH6F_HEAD_SEAT                              :{BLACK}头车座席：{GOLD}二等座{BLACK}带站席 (拥挤)，舒适度：{RED}128
 STR_CR300_HEAD_SEAT                              :{BLACK}头车座席：{GOLD}一等座
 # Misc
 STR_ELECTRICITY_SUPPLY_YES                       :{BLACK}机供：{GOLD}是

--- a/src/25-electric/6y2.pnml
+++ b/src/25-electric/6y2.pnml
@@ -82,7 +82,7 @@ item (FEAT_TRAINS, _6y2) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FR_IMPORT), string(STR_ELECTRICITY_SUPPLY_NO),  string(STR_6Y2_LIVERY_AVAILABILITY),string(STR_RELIABILITY_12));
+        additional_text:                string(STR_DESC_4, string(STR_FR_IMPORT), string(STR_ELECTRICITY_SUPPLY_NO),  string(STR_6Y2_LIVERY_AVAILABILITY),string(STR_RELDEC_LOW, 12));
         cargo_subtype_text:             switch_6y2_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/25-electric/hxd1.pnml
+++ b/src/25-electric/hxd1.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, hxd1) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD1), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXD1_NICKNAME), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD1), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXD1_NICKNAME), string(STR_RELDEC_LOW, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd1_graphics;

--- a/src/25-electric/hxd11000.pnml
+++ b/src/25-electric/hxd11000.pnml
@@ -72,7 +72,7 @@ item (FEAT_TRAINS, hxd11000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD11000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD11000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_LOW, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd11000_graphics;

--- a/src/25-electric/hxd1b.pnml
+++ b/src/25-electric/hxd1b.pnml
@@ -68,7 +68,7 @@ item (FEAT_TRAINS, hxd1b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD1B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXD1B_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD1B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXD1B_NICKNAME), string(STR_RELDEC_VERY_LOW, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd1b_graphics;

--- a/src/25-electric/hxd1d.pnml
+++ b/src/25-electric/hxd1d.pnml
@@ -68,7 +68,7 @@ item (FEAT_TRAINS, hxd1d) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD1D), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_HXD1D_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD1D), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_HXD1D_NICKNAME), string(STR_RELDEC_VERY_LOW, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd1d_graphics;

--- a/src/25-electric/hxd1f.pnml
+++ b/src/25-electric/hxd1f.pnml
@@ -99,7 +99,7 @@ item (FEAT_TRAINS, hxd1f) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_FXD1B), string(STR_ALIASNAME_FXD1B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_FXD1B), string(STR_ALIASNAME_FXD1B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_LOW, 8));
         cargo_subtype_text:             switch_hxd1f_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/25-electric/hxd2.pnml
+++ b/src/25-electric/hxd2.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, hxd2) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD2), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXD2_NICKNAME), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD2), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXD2_NICKNAME), string(STR_RELDEC_LOW, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd2_graphics;

--- a/src/25-electric/hxd21000.pnml
+++ b/src/25-electric/hxd21000.pnml
@@ -72,7 +72,7 @@ item (FEAT_TRAINS, hxd21000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD21000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXD2_NICKNAME), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD21000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXD2_NICKNAME), string(STR_RELDEC_LOW, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd21000_graphics;

--- a/src/25-electric/hxd3c.pnml
+++ b/src/25-electric/hxd3c.pnml
@@ -62,7 +62,7 @@ item (FEAT_TRAINS, hxd3c) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD3C), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_HXD3C_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD3C), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_HXD3C_NICKNAME), string(STR_RELDEC_VERY_LOW, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd3c_graphics;

--- a/src/25-electric/hxd3d.pnml
+++ b/src/25-electric/hxd3d.pnml
@@ -68,7 +68,7 @@ item (FEAT_TRAINS, hxd3d) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD3D), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_HXD3D_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXD3D), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_HXD3D_NICKNAME), string(STR_RELDEC_VERY_LOW, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxd3d_graphics;

--- a/src/25-electric/ss1.pnml
+++ b/src/25-electric/ss1.pnml
@@ -77,7 +77,7 @@ item (FEAT_TRAINS, ss1) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS1), string(STR_ALIASNME_SS1), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS1_NICKNAME), string(STR_RELIABILITY_20));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS1), string(STR_ALIASNME_SS1), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS1_NICKNAME), string(STR_RELDEC_HIGH, 20));
         cargo_subtype_text:             switch_ss1_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/25-electric/ss3.pnml
+++ b/src/25-electric/ss3.pnml
@@ -96,7 +96,7 @@ item (FEAT_TRAINS, ss3) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS3), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS3_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS3), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS3_NICKNAME), string(STR_RELDEC_LOW, 10));
         cargo_subtype_text:             switch_ss3_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/25-electric/ss3b.pnml
+++ b/src/25-electric/ss3b.pnml
@@ -67,7 +67,7 @@ item (FEAT_TRAINS, ss3b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS3B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS3B_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS3B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS3B_NICKNAME), string(STR_RELDEC_LOW, 10));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss3b_graphics;

--- a/src/25-electric/ss4.pnml
+++ b/src/25-electric/ss4.pnml
@@ -137,7 +137,7 @@ item (FEAT_TRAINS, ss4) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS4), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS4_NICKNAME), string(STR_RELIABILITY_20));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS4), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS4_NICKNAME), string(STR_RELDEC_HIGH, 20));
         cargo_subtype_text:             switch_ss4_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/25-electric/ss4b.pnml
+++ b/src/25-electric/ss4b.pnml
@@ -72,7 +72,7 @@ item (FEAT_TRAINS, ss4b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SS4B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SS4B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_LOW, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss4b_graphics;

--- a/src/25-electric/ss4c.pnml
+++ b/src/25-electric/ss4c.pnml
@@ -72,7 +72,7 @@ item (FEAT_TRAINS, ss4c) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SS4C), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SS4C), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_LOW, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss4c_graphics;

--- a/src/25-electric/ss4g.pnml
+++ b/src/25-electric/ss4g.pnml
@@ -99,7 +99,7 @@ item (FEAT_TRAINS, ss4g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS4G), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS4G_NICKNAME), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS4G), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS4G_NICKNAME), string(STR_RELDEC_LOW, 8));
         cargo_subtype_text:             switch_ss4g_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/25-electric/ss5.pnml
+++ b/src/25-electric/ss5.pnml
@@ -63,7 +63,7 @@ item (FEAT_TRAINS, ss5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS5_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS5_NICKNAME), string(STR_RELDEC_MEDIUM, 16));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss5_graphics;

--- a/src/25-electric/ss6.pnml
+++ b/src/25-electric/ss6.pnml
@@ -63,7 +63,7 @@ item (FEAT_TRAINS, ss6) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS6), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS6_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS6), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS6_NICKNAME), string(STR_RELDEC_LOW, 10));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss6_graphics;

--- a/src/25-electric/ss6b.pnml
+++ b/src/25-electric/ss6b.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, ss6b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS6B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS6B_NICKNAME), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS6B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS6B_NICKNAME), string(STR_RELDEC_LOW, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss6b_graphics;

--- a/src/25-electric/ss7.pnml
+++ b/src/25-electric/ss7.pnml
@@ -64,7 +64,7 @@ item (FEAT_TRAINS, ss7) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS7_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS7_NICKNAME), string(STR_RELDEC_MEDIUM, 16));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss7_graphics;

--- a/src/25-electric/ss7b.pnml
+++ b/src/25-electric/ss7b.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, ss7b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS7B_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_SS7B_NICKNAME), string(STR_RELDEC_MEDIUM, 16));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss7b_graphics;

--- a/src/25-electric/ss7c.pnml
+++ b/src/25-electric/ss7c.pnml
@@ -83,7 +83,7 @@ item (FEAT_TRAINS, ss7c) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_SS7C), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS7C_LIVERY_AVAILABILITY), string(STR_SS7C_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_SS7C), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS7C_LIVERY_AVAILABILITY), string(STR_SS7C_NICKNAME), string(STR_RELDEC_LOW, 10));
         cargo_subtype_text:             switch_ss7c_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/25-electric/ss7d.pnml
+++ b/src/25-electric/ss7d.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, ss7d) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7D), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS7D_NICKNAME), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7D), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS7D_NICKNAME), string(STR_RELDEC_LOW, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss7d_graphics;

--- a/src/25-electric/ss7e.pnml
+++ b/src/25-electric/ss7e.pnml
@@ -63,7 +63,7 @@ item (FEAT_TRAINS, ss7e) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7E), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS7E_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS7E), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS7E_NICKNAME), string(STR_RELDEC_VERY_LOW, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss7e_graphics;

--- a/src/25-electric/ss8.pnml
+++ b/src/25-electric/ss8.pnml
@@ -63,7 +63,7 @@ item (FEAT_TRAINS, ss8) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS8), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS8_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS8), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS8_NICKNAME), string(STR_RELDEC_LOW, 10));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss8_graphics;

--- a/src/25-electric/ss9.pnml
+++ b/src/25-electric/ss9.pnml
@@ -63,7 +63,7 @@ item (FEAT_TRAINS, ss9) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS9), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS9_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS9), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS9_NICKNAME), string(STR_RELDEC_VERY_LOW, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss9_graphics;

--- a/src/25-electric/ss9g.pnml
+++ b/src/25-electric/ss9g.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, ss9g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS9G), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS9G_NICKNAME), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SS9G), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_SS9G_NICKNAME), string(STR_RELDEC_VERY_LOW, 6));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_ss9g_graphics;

--- a/src/25-emu/cr200ja.pnml
+++ b/src/25-emu/cr200ja.pnml
@@ -347,7 +347,7 @@ item (FEAT_TRAINS, cr200ja) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR200J_NICKNAME), string(STR_RELIABILITY_20), string(STR_CR200J_CONSIST));
+        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR200J_NICKNAME), string(STR_RELDEC_HIGH, 20), string(STR_CR200J_CONSIST));
         can_attach_wagon:               cr200jawagon;
         start_stop:                     mu4car;
         // Graphics

--- a/src/25-emu/cr200jal.pnml
+++ b/src/25-emu/cr200jal.pnml
@@ -250,7 +250,7 @@ item (FEAT_TRAINS, cr200jal) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CR200J_CAN_ATTACH_WAGON), string(STR_CR200J_NICKNAME), string(STR_RELIABILITY_20), string(STR_CR200JL_CONSIST));
+        additional_text:                string(STR_DESC_4, string(STR_CR200J_CAN_ATTACH_WAGON), string(STR_CR200J_NICKNAME), string(STR_RELDEC_HIGH, 20), string(STR_CR200JL_CONSIST));
         can_attach_wagon:               cr200jalwagon;
         start_stop:                     mu8car;
         // Graphics

--- a/src/25-emu/cr200jb.pnml
+++ b/src/25-emu/cr200jb.pnml
@@ -307,7 +307,7 @@ item (FEAT_TRAINS, cr200jb) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR200J_NICKNAME), string(STR_RELIABILITY_12), string(STR_CR200J_CONSIST));
+        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR200J_NICKNAME), string(STR_RELDEC_LOW, 12), string(STR_CR200J_CONSIST));
         can_attach_wagon:               cr200jbwagon;
         start_stop:                     mu4car;
         // Graphics

--- a/src/25-emu/cr200jc.pnml
+++ b/src/25-emu/cr200jc.pnml
@@ -305,7 +305,7 @@ item (FEAT_TRAINS, cr200jc) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR200JC_NICKNAME), string(STR_RELIABILITY_8), string(STR_CR200J_CONSIST));
+        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR200JC_NICKNAME), string(STR_RELDEC_LOW, 8), string(STR_CR200J_CONSIST));
         can_attach_wagon:               cr200jcwagon;
         start_stop:                     switch_cr200jc_start_stop;
 

--- a/src/25-emu/cr200jcl.pnml
+++ b/src/25-emu/cr200jcl.pnml
@@ -179,7 +179,7 @@ item (FEAT_TRAINS, cr200jcl) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CR200J_CAN_ATTACH_WAGON), string(STR_CR200JC_NICKNAME), string(STR_RELIABILITY_8), string(STR_CR200JL_CONSIST));
+        additional_text:                string(STR_DESC_4, string(STR_CR200J_CAN_ATTACH_WAGON), string(STR_CR200JC_NICKNAME), string(STR_RELDEC_LOW, 8), string(STR_CR200JL_CONSIST));
         can_attach_wagon:               cr200jclwagon;
         start_stop:                     switch_cr200jcl_start_stop;
 

--- a/src/25-emu/cr300af.pnml
+++ b/src/25-emu/cr300af.pnml
@@ -273,7 +273,7 @@ item (FEAT_TRAINS, cr300af) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR300AF_NICKNAME), string(STR_CR300_CONSIST), string(STR_RELIABILITY_5), string(STR_CR300_HEAD_SEAT));
+        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR300AF_NICKNAME), string(STR_CR300_CONSIST), string(STR_RELDEC_VERY_LOW, 5), string(STR_CR300_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
 

--- a/src/25-emu/cr300bf.pnml
+++ b/src/25-emu/cr300bf.pnml
@@ -352,7 +352,7 @@ item (FEAT_TRAINS, cr300bf) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR300BF_NICKNAME), string(STR_CR300_CONSIST), string(STR_RELIABILITY_5), string(STR_CR300_HEAD_SEAT));
+        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR300BF_NICKNAME), string(STR_CR300_CONSIST), string(STR_RELDEC_VERY_LOW, 5), string(STR_CR300_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
 

--- a/src/25-emu/cr400af.pnml
+++ b/src/25-emu/cr400af.pnml
@@ -664,7 +664,7 @@ item (FEAT_TRAINS, cr400af) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400AF_NICKNAME), string(STR_RELIABILITY_5), string(STR_CR400_CONSIST), string(STR_CR400_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400AF_NICKNAME), string(STR_RELDEC_VERY_LOW, 5), string(STR_CR400_CONSIST), string(STR_CR400_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/cr400afab.pnml
+++ b/src/25-emu/cr400afab.pnml
@@ -279,7 +279,7 @@ item (FEAT_TRAINS, cr400afab) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400AF_NICKNAME), string(STR_RELIABILITY_5), string(STR_CR400_AB_CONSIST), string(STR_CR400_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400AF_NICKNAME), string(STR_RELDEC_VERY_LOW, 5), string(STR_CR400_AB_CONSIST), string(STR_CR400_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/cr400afabz.pnml
+++ b/src/25-emu/cr400afabz.pnml
@@ -344,7 +344,7 @@ item (FEAT_TRAINS, cr400afabz) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400_Z_NICKNAME), string(STR_RELIABILITY_3), string(STR_CR400_AB_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400_Z_NICKNAME), string(STR_RELDEC_VERY_LOW, 3), string(STR_CR400_AB_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/cr400afz.pnml
+++ b/src/25-emu/cr400afz.pnml
@@ -351,7 +351,7 @@ item (FEAT_TRAINS, cr400afz) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400_Z_NICKNAME),  string(STR_RELIABILITY_3), string(STR_CR400_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400_Z_NICKNAME),  string(STR_RELDEC_VERY_LOW, 3), string(STR_CR400_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/cr400bf.pnml
+++ b/src/25-emu/cr400bf.pnml
@@ -279,7 +279,7 @@ item (FEAT_TRAINS, cr400bf) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400BF_NICKNAME), string(STR_RELIABILITY_5), string(STR_CR400_CONSIST), string(STR_CR400_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400BF_NICKNAME), string(STR_RELDEC_VERY_LOW, 5), string(STR_CR400_CONSIST), string(STR_CR400_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/cr400bfab.pnml
+++ b/src/25-emu/cr400bfab.pnml
@@ -239,7 +239,7 @@ item (FEAT_TRAINS, cr400bfab) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400BF_NICKNAME), string(STR_RELIABILITY_5), string(STR_CR400_AB_CONSIST), string(STR_CR400_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400BF_NICKNAME), string(STR_RELDEC_VERY_LOW, 5), string(STR_CR400_AB_CONSIST), string(STR_CR400_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/cr400bfabz.pnml
+++ b/src/25-emu/cr400bfabz.pnml
@@ -256,7 +256,7 @@ item (FEAT_TRAINS, cr400bfabz) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400_Z_NICKNAME), string(STR_RELIABILITY_3), string(STR_CR400_AB_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400_Z_NICKNAME), string(STR_RELDEC_VERY_LOW, 3), string(STR_CR400_AB_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/cr400bfc.pnml
+++ b/src/25-emu/cr400bfc.pnml
@@ -395,7 +395,7 @@ item (FEAT_TRAINS, cr400bfc) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400BFC_NICKNAME), string(STR_RELIABILITY_3), string(STR_CR400_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400BFC_NICKNAME), string(STR_RELDEC_VERY_LOW, 3), string(STR_CR400_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         cargo_subtype_text:             swtich_cr400bfc_cargo_subtype;

--- a/src/25-emu/cr400bfz.pnml
+++ b/src/25-emu/cr400bfz.pnml
@@ -423,7 +423,7 @@ item (FEAT_TRAINS, cr400bfz) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400BFZ_LIVERY_AVAILABILITY), string(STR_CR400BFZ_NICKNAME), string(STR_RELIABILITY_3), string(STR_CR400_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
+        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CR400BFZ_LIVERY_AVAILABILITY), string(STR_CR400BFZ_NICKNAME), string(STR_RELDEC_VERY_LOW, 3), string(STR_CR400_Z_CONSIST), string(STR_CR400_Z_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         cargo_subtype_text:             swtich_cr400bfz_cargo_subtype;

--- a/src/25-emu/crh1a.pnml
+++ b/src/25-emu/crh1a.pnml
@@ -274,7 +274,7 @@ item (FEAT_TRAINS, crh1a) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH1A_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH1A_CONSIST), string(STR_CRH1A_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH1A_NICKNAME), string(STR_RELDEC_LOW, 12), string(STR_CRH1A_CONSIST), string(STR_CRH1A_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/crh1aa.pnml
+++ b/src/25-emu/crh1aa.pnml
@@ -252,7 +252,7 @@ item (FEAT_TRAINS, crh1aa) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH1AA_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH1AA_CONSIST), string(STR_CRH1AA_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH1AA_NICKNAME), string(STR_RELDEC_LOW, 12), string(STR_CRH1AA_CONSIST), string(STR_CRH1AA_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/crh1b.pnml
+++ b/src/25-emu/crh1b.pnml
@@ -201,7 +201,7 @@ item (FEAT_TRAINS, crh1b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH1B_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH1B_CONSIST), string(STR_CRH1B_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH1B_NICKNAME), string(STR_RELDEC_LOW, 12), string(STR_CRH1B_CONSIST), string(STR_CRH1B_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/crh1e.pnml
+++ b/src/25-emu/crh1e.pnml
@@ -234,7 +234,7 @@ item (FEAT_TRAINS, crh1e) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_SLEEPER_CAN_ATTACH_WAGON), string(STR_CRH1E_NICKNAME), string(STR_RELIABILITY_8), string(STR_CRH1E_CONSIST), string(STR_CRH1E_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_SLEEPER_CAN_ATTACH_WAGON), string(STR_CRH1E_NICKNAME), string(STR_RELDEC_LOW, 8), string(STR_CRH1E_CONSIST), string(STR_CRH1E_HEAD_SEAT));
         can_attach_wagon:               crhsleeperonly;
         start_stop:                     mu4car;
         

--- a/src/25-emu/crh2a.pnml
+++ b/src/25-emu/crh2a.pnml
@@ -383,7 +383,7 @@ item (FEAT_TRAINS, crh2a) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2A_NICKNAME), string(STR_RELIABILITY_20), string(STR_CRH2A_CONSIST), string(STR_CRH2A_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2A_NICKNAME), string(STR_RELDEC_HIGH, 20), string(STR_CRH2A_CONSIST), string(STR_CRH2A_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/crh2b.pnml
+++ b/src/25-emu/crh2b.pnml
@@ -270,7 +270,7 @@ item (FEAT_TRAINS, crh2b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2B_NICKNAME), string(STR_RELIABILITY_20), string(STR_CRH2B_CONSIST), string(STR_CRH2B_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2B_NICKNAME), string(STR_RELDEC_HIGH, 20), string(STR_CRH2B_CONSIST), string(STR_CRH2B_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
 

--- a/src/25-emu/crh2c.pnml
+++ b/src/25-emu/crh2c.pnml
@@ -320,7 +320,7 @@ item (FEAT_TRAINS, crh2c) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2C_NICKNAME), string(STR_RELIABILITY_15), string(STR_CRH2C_CONSIST), string(STR_CRH2C_HEAD_SEAT), string(STR_350_AVAILABLE));
+        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2C_NICKNAME), string(STR_RELDEC_MEDIUM, 15), string(STR_CRH2C_CONSIST), string(STR_CRH2C_HEAD_SEAT), string(STR_350_AVAILABLE));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         cargo_subtype_text:             switch_crh_c_cargo_subtype;

--- a/src/25-emu/crh2e.pnml
+++ b/src/25-emu/crh2e.pnml
@@ -314,7 +314,7 @@ item (FEAT_TRAINS, crh2e) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_SLEEPER_CAN_ATTACH_WAGON), string(STR_CRH2E_NICKNAME), string(STR_RELIABILITY_20), string(STR_CRH2E_CONSIST), string(STR_CRH2E_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_SLEEPER_CAN_ATTACH_WAGON), string(STR_CRH2E_NICKNAME), string(STR_RELDEC_HIGH, 20), string(STR_CRH2E_CONSIST), string(STR_CRH2E_HEAD_SEAT));
         can_attach_wagon:               crhsleeperonly;
         start_stop:                     mu4to24car;
         // Graphics

--- a/src/25-emu/crh2els.pnml
+++ b/src/25-emu/crh2els.pnml
@@ -204,7 +204,7 @@ item (FEAT_TRAINS, crh2els) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_LSLEEPER_CAN_ATTACH_WAGON), string(STR_CRH2G_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH2E_CONSIST), string(STR_CRH2ELS_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_LSLEEPER_CAN_ATTACH_WAGON), string(STR_CRH2G_NICKNAME), string(STR_RELDEC_LOW, 12), string(STR_CRH2E_CONSIST), string(STR_CRH2ELS_HEAD_SEAT));
         can_attach_wagon:               crh_wagons_longitudinal_sleeper;
         start_stop:                     mu4car;
         // Graphics

--- a/src/25-emu/crh2g.pnml
+++ b/src/25-emu/crh2g.pnml
@@ -320,7 +320,7 @@ item (FEAT_TRAINS, crh2g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2G_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH2G_CONSIST), string(STR_CRH2G_HEAD_SEAT));
+        additional_text:                string(STR_DESC_4, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH2G_NICKNAME), string(STR_RELDEC_LOW, 12), string(STR_CRH2G_CONSIST), string(STR_CRH2G_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4car;
         // Graphics

--- a/src/25-emu/crh380a.pnml
+++ b/src/25-emu/crh380a.pnml
@@ -355,7 +355,7 @@ item (FEAT_TRAINS, crh380a) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380A_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH380A_CONSIST), string(STR_CRH380A_HEAD_SEAT), string(STR_350_380_AVAILABLE));
+        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380A_NICKNAME), string(STR_RELDEC_LOW, 12), string(STR_CRH380A_CONSIST), string(STR_CRH380A_HEAD_SEAT), string(STR_350_380_AVAILABLE));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         cargo_subtype_text:             switch_crh380_cargo_subtype;

--- a/src/25-emu/crh380al.pnml
+++ b/src/25-emu/crh380al.pnml
@@ -242,7 +242,7 @@ item (FEAT_TRAINS, crh380al) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380A_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH380AL_CONSIST), string(STR_CRH380A_HEAD_SEAT), string(STR_350_380_AVAILABLE));
+        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380A_NICKNAME), string(STR_RELDEC_LOW, 12), string(STR_CRH380AL_CONSIST), string(STR_CRH380A_HEAD_SEAT), string(STR_350_380_AVAILABLE));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         cargo_subtype_text:             switch_crh380_cargo_subtype;

--- a/src/25-emu/crh380b.pnml
+++ b/src/25-emu/crh380b.pnml
@@ -195,7 +195,7 @@ item (FEAT_TRAINS, crh380b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380B_NICKNAME), string(STR_RELIABILITY_5), string(STR_CRH380B_CONSIST), string(STR_CRH380B_HEAD_SEAT), string(STR_350_380_AVAILABLE));
+        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380B_NICKNAME), string(STR_RELDEC_VERY_LOW, 5), string(STR_CRH380B_CONSIST), string(STR_CRH380B_HEAD_SEAT), string(STR_350_380_AVAILABLE));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh380_cargo_subtype;

--- a/src/25-emu/crh380cl.pnml
+++ b/src/25-emu/crh380cl.pnml
@@ -190,7 +190,7 @@ item (FEAT_TRAINS, crh380cl) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380CL_NICKNAME), string(STR_RELIABILITY_5), string(STR_CRH380CL_CONSIST), string(STR_CRH380CL_HEAD_SEAT), string(STR_350_380_AVAILABLE));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380CL_NICKNAME), string(STR_RELDEC_VERY_LOW, 5), string(STR_CRH380CL_CONSIST), string(STR_CRH380CL_HEAD_SEAT), string(STR_350_380_AVAILABLE));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh380_cargo_subtype;

--- a/src/25-emu/crh380d.pnml
+++ b/src/25-emu/crh380d.pnml
@@ -334,7 +334,7 @@ item (FEAT_TRAINS, crh380d) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380D_NICKNAME), string(STR_CRH380D_CONSIST), string(STR_RELIABILITY_5), string(STR_CRH380D_HEAD_SEAT));
+        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH380D_NICKNAME), string(STR_CRH380D_CONSIST), string(STR_RELDEC_VERY_LOW, 5), string(STR_CRH380D_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4to24car;
         cargo_subtype_text:             switch_crh380_cargo_subtype;

--- a/src/25-emu/crh3a.pnml
+++ b/src/25-emu/crh3a.pnml
@@ -243,7 +243,7 @@ item (FEAT_TRAINS, crh3a) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH3A_NICKNAME), string(STR_RELIABILITY_8), string(STR_CRH3A_CONSIST), string(STR_CRH3A_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH3A_NICKNAME), string(STR_RELDEC_LOW, 8), string(STR_CRH3A_CONSIST), string(STR_CRH3A_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4car;
         // Graphics

--- a/src/25-emu/crh3c.pnml
+++ b/src/25-emu/crh3c.pnml
@@ -201,7 +201,7 @@ item (FEAT_TRAINS, crh3c) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH3C_NICKNAME), string(STR_RELIABILITY_12), string(STR_CRH3C_CONSIST), string(STR_CRH3C_HEAD_SEAT), string(STR_350_AVAILABLE));
+        additional_text:                string(STR_DESC_6, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH3C_NICKNAME), string(STR_RELDEC_LOW, 12), string(STR_CRH3C_CONSIST), string(STR_CRH3C_HEAD_SEAT), string(STR_350_AVAILABLE));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh_c_cargo_subtype;

--- a/src/25-emu/crh5a.pnml
+++ b/src/25-emu/crh5a.pnml
@@ -323,7 +323,7 @@ item (FEAT_TRAINS, crh5a) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH5A_NICKNAME), string(STR_RELIABILITY_16), string(STR_CRH5A_CONSIST), string(STR_CRH5A_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH_CAN_ATTACH_WAGON), string(STR_CRH5A_NICKNAME), string(STR_RELDEC_MEDIUM, 16), string(STR_CRH5A_CONSIST), string(STR_CRH5A_HEAD_SEAT));
         can_attach_wagon:               crhwagon;
         start_stop:                     mu481216car;
         // Graphics

--- a/src/25-emu/crh6a2.pnml
+++ b/src/25-emu/crh6a2.pnml
@@ -353,7 +353,7 @@ item (FEAT_TRAINS, crh6a2) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH6A2_CAN_ATTACH_WAGON), string(STR_CRH6A2_LIVERY_AVAILABILITY), string(STR_RELIABILITY_8), string(STR_CRH6A2_CONSIST), string(STR_CRH6A2_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH6A2_CAN_ATTACH_WAGON), string(STR_CRH6A2_LIVERY_AVAILABILITY), string(STR_RELDEC_LOW, 8), string(STR_CRH6A2_CONSIST), string(STR_CRH6A2_HEAD_SEAT));
         can_attach_wagon:               onlyzezy;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh6a2_cargo_subtype;

--- a/src/25-emu/crh6a3.pnml
+++ b/src/25-emu/crh6a3.pnml
@@ -198,7 +198,7 @@ item (FEAT_TRAINS, crh6a3) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CRH6A3_CAN_ATTACH_WAGON), string(STR_CRH6A3_LIVERY_AVAILABILITY), string(STR_RELIABILITY_8), string(STR_CRH6A3_CONSIST), string(STR_CRH6A3_HEAD_SEAT));
+        additional_text:                string(STR_DESC_4, string(STR_CRH6A3_CAN_ATTACH_WAGON), string(STR_CRH6A3_LIVERY_AVAILABILITY), string(STR_RELDEC_LOW, 8), string(STR_CRH6A3_CONSIST), string(STR_CRH6A3_HEAD_SEAT));
         can_attach_wagon:               onlyze;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh6a3_cargo_subtype;

--- a/src/25-emu/crh6aa.pnml
+++ b/src/25-emu/crh6aa.pnml
@@ -206,7 +206,7 @@ item (FEAT_TRAINS, crh6aa) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_RELIABILITY_6), string(STR_CRH6AA_LIVERY_AVAILABILITY), string(STR_CRH6AA_CONSIST), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_4, string(STR_RELDEC_VERY_LOW, 6), string(STR_CRH6AA_LIVERY_AVAILABILITY), string(STR_CRH6AA_CONSIST), string(STR_COMFORT_LOW, 160));
         can_attach_wagon:               onlycrh6aa;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh6aa_cargo_subtype;

--- a/src/25-emu/crh6f.pnml
+++ b/src/25-emu/crh6f.pnml
@@ -194,7 +194,7 @@ item (FEAT_TRAINS, crh6f) {
         ai_special_flag:                AI_FLAG_PASSENGER;
         cargo_capacity:                 1;
         loading_speed:                  18 << param_loading_speed;
-        cargo_age_period:               120 << param_cargo_decay;
+        cargo_age_period:               128 << param_cargo_decay;
 
         // Stats
         speed:                          160 km/h;
@@ -209,7 +209,7 @@ item (FEAT_TRAINS, crh6f) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_CRH6F_CAN_ATTACH_WAGON), string(STR_CRH6F_NICKNAME), string(STR_CRH6F_LIVERY_AVAILABILITY), string(STR_RELIABILITY_6), string(STR_CRH6F_CONSIST), string(STR_CRH6F_HEAD_SEAT));
+        additional_text:                string(STR_DESC_5, string(STR_CRH6F_CAN_ATTACH_WAGON), string(STR_CRH6F_NICKNAME), string(STR_CRH6F_LIVERY_AVAILABILITY), string(STR_RELDEC_VERY_LOW, 6), string(STR_CRH6F_CONSIST), string(STR_CRH6F_HEAD_SEAT));
         can_attach_wagon:               onlyze;
         start_stop:                     mu4car;
         cargo_subtype_text:             switch_crh6f_cargo_subtype;
@@ -226,7 +226,7 @@ item (FEAT_TRAINS, crh6f) {
         tractive_effort_coefficient:    return 0;
         purchase_tractive_effort_coefficient: return int(0.2*255);
         cargo_capacity:                 switch_crh6f_head_capacity;
-        cargo_age_period:               140 << param_cargo_decay;
+        cargo_age_period:               128 << param_cargo_decay;
         cost_factor:                    65;
         running_cost_factor:            50 * runningcostfactor() + 20;
         purchase_running_cost_factor:   220;
@@ -244,7 +244,7 @@ item (FEAT_TRAINS, crh6f) {
         length:                         switch_length_2_8_2;
         weight:                         48;
         can_attach_wagon:               muhead;
-        cargo_age_period:               120 << param_cargo_decay;
+        cargo_age_period:               128 << param_cargo_decay;
         bitmask_vehicle_info:           switch_crh_wagon_bitmask;
         articulated_part:               switch_crh_wagon_articulated_part;
         cost_factor:                    switch_crh6f_wagon_cost;

--- a/src/25-emu/djj1.pnml
+++ b/src/25-emu/djj1.pnml
@@ -151,7 +151,7 @@ item (FEAT_TRAINS, djj1) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_DJJ1_LIVERY_AVAILABILITY), string(STR_DJJ1_CAN_ATTACH_WAGON), string(STR_DJJ1_CONSIST), string(STR_RELIABILITY_24));
+        additional_text:                string(STR_DESC_4, string(STR_DJJ1_LIVERY_AVAILABILITY), string(STR_DJJ1_CAN_ATTACH_WAGON), string(STR_DJJ1_CONSIST), string(STR_RELDEC_HIGH, 24));
         can_attach_wagon:               djj1wagon;
         start_stop:                     switch_djj1_start_stop;
         cargo_subtype_text:             swtich_djj1_cargo_subtype;

--- a/src/coaches/19/rw19k.pnml
+++ b/src/coaches/19/rw19k.pnml
@@ -100,7 +100,7 @@ item (FEAT_TRAINS, rw19k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW19K), string(STR_19K_LIVERY_AVAILABILITY), string(STR_COMFORT_640));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW19K), string(STR_19K_LIVERY_AVAILABILITY), string(STR_COMFORT_VERY_HIGH, 640));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rw19k_cargo_subtype;
 

--- a/src/coaches/19/rw19t.pnml
+++ b/src/coaches/19/rw19t.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rw19t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_FULL_NAME_RW19T), string(STR_COMFORT_640));
+        additional_text:                string(STR_DESC_2, string(STR_FULL_NAME_RW19T), string(STR_COMFORT_VERY_HIGH, 640));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/22/ca23.pnml
+++ b/src/coaches/22/ca23.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, ca23) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA23), string(STR_CAFE_EFFECT), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_144_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA23), string(STR_CAFE_EFFECT), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 180));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_ca23_cargo_subtype;
 

--- a/src/coaches/22/ca23aircon.pnml
+++ b/src/coaches/22/ca23aircon.pnml
@@ -91,7 +91,7 @@ item (FEAT_TRAINS, ca23aircon) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA23AIRCON), string(STR_CAFE_EFFECT), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_160_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA23AIRCON), string(STR_CAFE_EFFECT), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_ca23aircon_cargo_subtype;
 

--- a/src/coaches/22/rw22.pnml
+++ b/src/coaches/22/rw22.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, rw22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT_384), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 384), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rw22_cargo_subtype;
 

--- a/src/coaches/22/rw22aircon.pnml
+++ b/src/coaches/22/rw22aircon.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, rw22aircon) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 384));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rw22aircon_cargo_subtype;
 

--- a/src/coaches/22/rz22.pnml
+++ b/src/coaches/22/rz22.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, rz22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RZ22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT_192), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RZ22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rz22_cargo_subtype;
 

--- a/src/coaches/22/rz22aircon.pnml
+++ b/src/coaches/22/rz22aircon.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, rz22aircon) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rz22aircon_cargo_subtype;
 

--- a/src/coaches/22/uz22.pnml
+++ b/src/coaches/22/uz22.pnml
@@ -99,7 +99,7 @@ item (FEAT_TRAINS, uz22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_UZ22), string(STR_22_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_UZ22), string(STR_22_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_uz22_cargo_subtype;
 

--- a/src/coaches/22/xl22.pnml
+++ b/src/coaches/22/xl22.pnml
@@ -99,7 +99,7 @@ item (FEAT_TRAINS, xl22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL22), string(STR_22_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL22), string(STR_22_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_xl22_cargo_subtype;
 

--- a/src/coaches/22/yw22.pnml
+++ b/src/coaches/22/yw22.pnml
@@ -95,7 +95,7 @@ item (FEAT_TRAINS, yw22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT, 300), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 300), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
 
@@ -160,7 +160,7 @@ item (FEAT_TRAINS, yw221966) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT, 360), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 360), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
 

--- a/src/coaches/22/yw22aircon.pnml
+++ b/src/coaches/22/yw22aircon.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, yw22aircon) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 288));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_yw22aircon_cargo_subtype;
 

--- a/src/coaches/22/yz22.pnml
+++ b/src/coaches/22/yz22.pnml
@@ -86,7 +86,7 @@ item (FEAT_TRAINS, yz22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT_144), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ22), string(STR_22_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 144), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_yz22_cargo_subtype;
 

--- a/src/coaches/22/yz22aircon.pnml
+++ b/src/coaches/22/yz22aircon.pnml
@@ -86,7 +86,7 @@ item (FEAT_TRAINS, yz22aircon) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ22AIRCON), string(STR_22AIRCON_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_yz22aircon_cargo_subtype;
 

--- a/src/coaches/22b/rw22b.pnml
+++ b/src/coaches/22b/rw22b.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rw22b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW22B), string(STR_22B_LIVERY_AVAILABILITY), string(STR_COMFORT_384_AC), string(STR_SELF_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW22B), string(STR_22B_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 480), string(STR_SELF_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/22b/yw22b.pnml
+++ b/src/coaches/22b/yw22b.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, yw22b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW22B), string(STR_22B_LIVERY_AVAILABILITY), string(STR_COMFORT_288), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW22B), string(STR_22B_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 288), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/22b/yz22b.pnml
+++ b/src/coaches/22b/yz22b.pnml
@@ -67,7 +67,7 @@ item (FEAT_TRAINS, yz22b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ22B), string(STR_22B_LIVERY_AVAILABILITY), string(STR_COMFORT_144), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ22B), string(STR_22B_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 144), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25/ca25ml.pnml
+++ b/src/coaches/25/ca25ml.pnml
@@ -90,7 +90,7 @@ item (FEAT_TRAINS, ca25ml) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25ML), string(STR_CAFE_EFFECT), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_160_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25ML), string(STR_CAFE_EFFECT), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 200));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25/rw25ml.pnml
+++ b/src/coaches/25/rw25ml.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, rw25ml) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 384));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25/xl25ml.pnml
+++ b/src/coaches/25/xl25ml.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, xl25ml) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 200));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25/yw25ml.pnml
+++ b/src/coaches/25/yw25ml.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, yw25ml) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 288));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25/yz25ml.pnml
+++ b/src/coaches/25/yz25ml.pnml
@@ -86,7 +86,7 @@ item (FEAT_TRAINS, yz25ml) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25ML), string(STR_25ML_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 160));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25b/rw25b.pnml
+++ b/src/coaches/25b/rw25b.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rw25b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW25B), string(STR_RW25B_LIVERY_AVAILABILITY), string(STR_COMFORT_384_AC), string(STR_SELF_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW25B), string(STR_RW25B_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 480), string(STR_SELF_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25b/rz25b.pnml
+++ b/src/coaches/25b/rz25b.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rz25b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RZ25B), string(STR_25B_LIVERY_AVAILABILITY), string(STR_COMFORT_192), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RZ25B), string(STR_25B_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25b/srw25bhd.pnml
+++ b/src/coaches/25b/srw25bhd.pnml
@@ -53,7 +53,7 @@ item (FEAT_TRAINS, srw25bhd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRW25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRW25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 384));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25bhd_cargo_subtype;
 

--- a/src/coaches/25b/srz25bhd.pnml
+++ b/src/coaches/25b/srz25bhd.pnml
@@ -53,7 +53,7 @@ item (FEAT_TRAINS, srz25bhd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25bhd_cargo_subtype;
 

--- a/src/coaches/25b/srz25bld.pnml
+++ b/src/coaches/25b/srz25bld.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, srz25bld) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25B), string(STR_S25BLD_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25B), string(STR_S25BLD_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25bld_cargo_subtype;
 

--- a/src/coaches/25b/syw25bhd.pnml
+++ b/src/coaches/25b/syw25bhd.pnml
@@ -53,7 +53,7 @@ item (FEAT_TRAINS, syw25bhd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYW25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYW25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 288));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25bhd_cargo_subtype;
 

--- a/src/coaches/25b/syz25bhd.pnml
+++ b/src/coaches/25b/syz25bhd.pnml
@@ -86,7 +86,7 @@ item (FEAT_TRAINS, syz25bhd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25B), string(STR_S25BHD_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25bhd_cargo_subtype;
 

--- a/src/coaches/25b/syz25bld.pnml
+++ b/src/coaches/25b/syz25bld.pnml
@@ -96,7 +96,7 @@ item (FEAT_TRAINS, syz25bld) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25B), string(STR_S25BLD_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25B), string(STR_S25BLD_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25bld_cargo_subtype;
 

--- a/src/coaches/25b/xl25b.pnml
+++ b/src/coaches/25b/xl25b.pnml
@@ -98,7 +98,7 @@ item (FEAT_TRAINS, xl25b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25B), string(STR_XL25B_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25B), string(STR_XL25B_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_xl25b_cargo_subtype;
 

--- a/src/coaches/25b/yw25b.pnml
+++ b/src/coaches/25b/yw25b.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, yw25b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW25B), string(STR_25B_LIVERY_AVAILABILITY), string(STR_COMFORT_288), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW25B), string(STR_25B_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 288), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25b/yz25b.pnml
+++ b/src/coaches/25b/yz25b.pnml
@@ -89,7 +89,7 @@ item (FEAT_TRAINS, yz25b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ25B), string(STR_25B_LIVERY_AVAILABILITY), string(STR_COMFORT_144), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ25B), string(STR_25B_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 144), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25dt/rw25dt_jinlun.pnml
+++ b/src/coaches/25dt/rw25dt_jinlun.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, rw25dt_jinlun) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_RW25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 384));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_25dt_jinlun_cargo_subtype;
 

--- a/src/coaches/25dt/srz25dt_jinlun.pnml
+++ b/src/coaches/25dt/srz25dt_jinlun.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, srz25dt_jinlun) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SRZ25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SRZ25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_25dt_jinlun_cargo_subtype;
 

--- a/src/coaches/25dt/syz25dt_jinlun.pnml
+++ b/src/coaches/25dt/syz25dt_jinlun.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, syz25dt_jinlun) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SYZ25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SYZ25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_25dt_jinlun_cargo_subtype;
 

--- a/src/coaches/25dt/yw25dt_jinlun.pnml
+++ b/src/coaches/25dt/yw25dt_jinlun.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, yw25dt_jinlun) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YW25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 288));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_25dt_jinlun_cargo_subtype;
 

--- a/src/coaches/25dt/yz25dt_jinlun.pnml
+++ b/src/coaches/25dt/yz25dt_jinlun.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, yz25dt_jinlun) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ25DT_JINLUN), string(STR_JINLUN_25DT), string(STR_25DT_JINLUN_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_25dt_jinlun_cargo_subtype;
 

--- a/src/coaches/25g/ca25g.pnml
+++ b/src/coaches/25g/ca25g.pnml
@@ -98,7 +98,7 @@ item (FEAT_TRAINS, ca25g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25G), string(STR_CAFE_EFFECT), string(STR_CA25G_LIVERY_AVAILABILITY), string(STR_COMFORT_160_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25G), string(STR_CAFE_EFFECT), string(STR_CA25G_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_ca25g_cargo_subtype;
 

--- a/src/coaches/25g/rw25g.pnml
+++ b/src/coaches/25g/rw25g.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rw25g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 384));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25g/rz25g.pnml
+++ b/src/coaches/25g/rz25g.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rz25g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25g/xl25g.pnml
+++ b/src/coaches/25g/xl25g.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, xl25g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_xl25g_cargo_subtype;
 

--- a/src/coaches/25g/yw25g.pnml
+++ b/src/coaches/25g/yw25g.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, yw25g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 288));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25g/yz25g.pnml
+++ b/src/coaches/25g/yz25g.pnml
@@ -94,7 +94,7 @@ item (FEAT_TRAINS, yz25g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25G), string(STR_25G_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 160));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/ca25k.pnml
+++ b/src/coaches/25k/ca25k.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, ca25k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25K), string(STR_CAFE_EFFECT), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_160_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25K), string(STR_CAFE_EFFECT), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 200));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/rw25k.pnml
+++ b/src/coaches/25k/rw25k.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rw25k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 384));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/rz25k.pnml
+++ b/src/coaches/25k/rz25k.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, rz25k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/sca25khd.pnml
+++ b/src/coaches/25k/sca25khd.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, sca25khd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SCA25K), string(STR_SCA25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_160_CAFE), string(STR_CAFE_EFFECT));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SCA25K), string(STR_SCA25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 200), string(STR_CAFE_EFFECT));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/srw25khd.pnml
+++ b/src/coaches/25k/srw25khd.pnml
@@ -73,7 +73,7 @@ item (FEAT_TRAINS, srw25khd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRW25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRW25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 384));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25khd_cargo_subtype;
 

--- a/src/coaches/25k/srz25khd.pnml
+++ b/src/coaches/25k/srz25khd.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, srz25khd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25khd_cargo_subtype;
 

--- a/src/coaches/25k/srz25kld.pnml
+++ b/src/coaches/25k/srz25kld.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, srz25kld) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25K), string(STR_S25KLD_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ25K), string(STR_S25KLD_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25kld_cargo_subtype;
 

--- a/src/coaches/25k/syw25khd.pnml
+++ b/src/coaches/25k/syw25khd.pnml
@@ -73,7 +73,7 @@ item (FEAT_TRAINS, syw25khd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYW25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYW25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 288));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25khd_cargo_subtype;
 

--- a/src/coaches/25k/syz25khd.pnml
+++ b/src/coaches/25k/syz25khd.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, syz25khd) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25K), string(STR_S25KHD_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25khd_cargo_subtype;
 

--- a/src/coaches/25k/syz25kld.pnml
+++ b/src/coaches/25k/syz25kld.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, syz25kld) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25K), string(STR_S25KLD_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYZ25K), string(STR_S25KLD_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_s25kld_cargo_subtype;
 

--- a/src/coaches/25k/xl25k.pnml
+++ b/src/coaches/25k/xl25k.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, xl25k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 200));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/yw25k.pnml
+++ b/src/coaches/25k/yw25k.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, yw25k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 288));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25k/yz25k.pnml
+++ b/src/coaches/25k/yz25k.pnml
@@ -67,7 +67,7 @@ item (FEAT_TRAINS, yz25k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25K), string(STR_25K_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 160));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25t/ca25t.pnml
+++ b/src/coaches/25t/ca25t.pnml
@@ -94,7 +94,7 @@ item (FEAT_TRAINS, ca25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25T), string(STR_CAFE_EFFECT), string(STR_CA25T_LIVERY_AVAILABILITY), string(STR_COMFORT_160_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25T), string(STR_CAFE_EFFECT), string(STR_CA25T_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_ca25t_cargo_subtype;
 

--- a/src/coaches/25t/rw25t.pnml
+++ b/src/coaches/25t/rw25t.pnml
@@ -104,7 +104,7 @@ item (FEAT_TRAINS, rw25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25T), string(STR_BSP25T_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RW25T), string(STR_BSP25T_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 384));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rw25t_cargo_subtype;
 

--- a/src/coaches/25t/rz25t.pnml
+++ b/src/coaches/25t/rz25t.pnml
@@ -101,7 +101,7 @@ item (FEAT_TRAINS, rz25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ25T), string(STR_BSP25T_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ25T), string(STR_BSP25T_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rz25t_cargo_subtype;
 

--- a/src/coaches/25t/uz25t.pnml
+++ b/src/coaches/25t/uz25t.pnml
@@ -96,7 +96,7 @@ item (FEAT_TRAINS, uz25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_UZ25T), string(STR_UZ25T_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_UZ25T), string(STR_UZ25T_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_uz25t_cargo_subtype;
 

--- a/src/coaches/25t/xl25t.pnml
+++ b/src/coaches/25t/xl25t.pnml
@@ -102,7 +102,7 @@ item (FEAT_TRAINS, xl25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25T), string(STR_XL25T_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_XL25T), string(STR_XL25T_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 200));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_xl25t_cargo_subtype;
 

--- a/src/coaches/25t/xl25t_sspe.pnml
+++ b/src/coaches/25t/xl25t_sspe.pnml
@@ -70,7 +70,7 @@ item (FEAT_TRAINS, xl25t_sspe) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_XL25T_SSPE_DESCRIPTION), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_2, string(STR_XL25T_SSPE_DESCRIPTION), string(STR_FRESHNESS_MEDIUM, 200));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25t/yw25t.pnml
+++ b/src/coaches/25t/yw25t.pnml
@@ -96,7 +96,7 @@ item (FEAT_TRAINS, yw25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25T), string(STR_25T_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YW25T), string(STR_25T_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 288));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_yw25t_cargo_subtype;
 

--- a/src/coaches/25t/yz25t.pnml
+++ b/src/coaches/25t/yz25t.pnml
@@ -96,7 +96,7 @@ item (FEAT_TRAINS, yz25t) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25T), string(STR_25T_LIVERY_AVAILABILITY), string(STR_COMFORT_160));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_YZ25T), string(STR_25T_LIVERY_AVAILABILITY), string(STR_COMFORT_LOW, 160));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_yz25t_cargo_subtype;
 

--- a/src/coaches/25z/ca25z.pnml
+++ b/src/coaches/25z/ca25z.pnml
@@ -90,7 +90,7 @@ item (FEAT_TRAINS, ca25z) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25Z), string(STR_CAFE_EFFECT), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_192_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_CA25Z), string(STR_CAFE_EFFECT), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 240));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_ca25z_cargo_subtype;
 

--- a/src/coaches/25z/rz125z.pnml
+++ b/src/coaches/25z/rz125z.pnml
@@ -95,7 +95,7 @@ item (FEAT_TRAINS, rz125z) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ125Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_256));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ125Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 256));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rz125z_cargo_subtype;
 

--- a/src/coaches/25z/rz225z.pnml
+++ b/src/coaches/25z/rz225z.pnml
@@ -91,7 +91,7 @@ item (FEAT_TRAINS, rz225z) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ225Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZ225Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_rz225z_cargo_subtype;
 

--- a/src/coaches/25z/rzt25z.pnml
+++ b/src/coaches/25z/rzt25z.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, rzt25z) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZT25Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_320));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZT25Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 320));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_rzt25z_graphics;

--- a/src/coaches/25z/rzxl25z.pnml
+++ b/src/coaches/25z/rzxl25z.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, rzxl25z) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZXL25Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_RZXL25Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 200));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_rzxl25z_graphics;

--- a/src/coaches/25z/sca25z.pnml
+++ b/src/coaches/25z/sca25z.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, sca25z) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SCA25Z), string(STR_CAFE_EFFECT), string(STR_S25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_192_CAFE));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_SCA25Z), string(STR_CAFE_EFFECT), string(STR_S25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 240));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/coaches/25z/srw25.pnml
+++ b/src/coaches/25z/srw25.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, srw25) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRW25), string(STR_S25_LIVERY_AVAILABILITY), string(STR_COMFORT_384));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRW25), string(STR_S25_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 384));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_srw25_graphics;

--- a/src/coaches/25z/srz125z.pnml
+++ b/src/coaches/25z/srz125z.pnml
@@ -85,7 +85,7 @@ item (FEAT_TRAINS, srz125z) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ125Z), string(STR_S25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_256));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ125Z), string(STR_S25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 256));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_srz125z_cargo_subtype;
 

--- a/src/coaches/25z/srz225z.pnml
+++ b/src/coaches/25z/srz225z.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, srz225z) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ225Z), string(STR_S25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_192));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZ225Z), string(STR_S25Z_LIVERY_AVAILABILITY), string(STR_COMFORT_MEDIUM, 192));
         can_attach_wagon:               locowagon;
         cargo_subtype_text:             switch_srz225z_cargo_subtype;
 

--- a/src/coaches/25z/srzxl25z.pnml
+++ b/src/coaches/25z/srzxl25z.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, srzxl25z) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZXL25Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_DECAY_200));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SRZXL25Z), string(STR_25Z_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 200));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_srzxl25z_graphics;

--- a/src/coaches/25z/syw25.pnml
+++ b/src/coaches/25z/syw25.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, syw25) {
 
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYW25), string(STR_S25_LIVERY_AVAILABILITY), string(STR_COMFORT_288));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SYW25), string(STR_S25_LIVERY_AVAILABILITY), string(STR_COMFORT_HIGH, 288));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_syw25_graphics;

--- a/src/coaches/31/yz31.pnml
+++ b/src/coaches/31/yz31.pnml
@@ -80,7 +80,7 @@ item (FEAT_TRAINS, yz31) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ31), string(STR_YZ31_LIVERY_AVAILABILITY), string(STR_COMFORT_108), string(STR_NO_AIR_CONDITIONER));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_YZ31), string(STR_YZ31_LIVERY_AVAILABILITY), string(STR_COMFORT_VERY_LOW, 108), string(STR_NO_AIR_CONDITIONER));
         can_attach_wagon:               locowagon;
 //        cargo_subtype_text:             switch_yz31_cargo_subtype;
 

--- a/src/diesel/df.pnml
+++ b/src/diesel/df.pnml
@@ -95,7 +95,7 @@ item (FEAT_TRAINS, df) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_6, string(STR_FULL_NAME_DF),  string(STR_ALIASNAME_DF), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF_LIVERY_AVAILABILITY), string(STR_DF_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_6, string(STR_FULL_NAME_DF),  string(STR_ALIASNAME_DF), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF_LIVERY_AVAILABILITY), string(STR_DF_NICKNAME), string(STR_RELDEC_MEDIUM, 16));
         cargo_subtype_text:             switch_df_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df11.pnml
+++ b/src/diesel/df11.pnml
@@ -65,7 +65,7 @@ item (FEAT_TRAINS, df11) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF11), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF11_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF11), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF11_NICKNAME), string(STR_RELDEC_LOW, 10));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/diesel/df11g.pnml
+++ b/src/diesel/df11g.pnml
@@ -111,7 +111,7 @@ item (FEAT_TRAINS, df11g) {
     }
     graphics {
         // Menu
-        additional_text:                        string(STR_DESC_6, string(STR_FULL_NAME_DF11G), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_DF11G_NICKNAME), string(STR_RELIABILITY_6), string(STR_DF11G_CONSIST), string(STR_LEAPING_LIU_NEVER_DIES));
+        additional_text:                        string(STR_DESC_6, string(STR_FULL_NAME_DF11G), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_DF11G_NICKNAME), string(STR_RELDEC_VERY_LOW, 6), string(STR_DF11G_CONSIST), string(STR_LEAPING_LIU_NEVER_DIES));
         can_attach_wagon:                       locowagon;
 
         // Graphics

--- a/src/diesel/df11z.pnml
+++ b/src/diesel/df11z.pnml
@@ -66,7 +66,7 @@ item (FEAT_TRAINS, df11z) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF11Z), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF11Z), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_MEDIUM, 14));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_df11z_graphics;

--- a/src/diesel/df4bh.pnml
+++ b/src/diesel/df4bh.pnml
@@ -106,7 +106,7 @@ item (FEAT_TRAINS, df4bh) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4B_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4B_NICKNAME), string(STR_RELDEC_MEDIUM, 14));
         cargo_subtype_text:             switch_df4bh_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4bk.pnml
+++ b/src/diesel/df4bk.pnml
@@ -93,7 +93,7 @@ item (FEAT_TRAINS, df4bk) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4B_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4B_NICKNAME), string(STR_RELDEC_MEDIUM, 14));
         cargo_subtype_text:             switch_df4bk_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4c.pnml
+++ b/src/diesel/df4c.pnml
@@ -85,7 +85,7 @@ item (FEAT_TRAINS, df4c) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4C), string(STR_ALIASNAME_DF), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4C_LIVERY_AVAILABILITY), string(STR_DF4C_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4C), string(STR_ALIASNAME_DF), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4C_LIVERY_AVAILABILITY), string(STR_DF4C_NICKNAME), string(STR_RELDEC_MEDIUM, 16));
         cargo_subtype_text:             switch_df4c_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4d0000.pnml
+++ b/src/diesel/df4d0000.pnml
@@ -87,7 +87,7 @@ item (FEAT_TRAINS, df4d0000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4D), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D0000_LIVERY_AVAILABILITY), string(STR_DF4D_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4D), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D0000_LIVERY_AVAILABILITY), string(STR_DF4D_NICKNAME), string(STR_RELDEC_MEDIUM, 14));
         cargo_subtype_text:             switch_df4d0000_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4d3000.pnml
+++ b/src/diesel/df4d3000.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, df4d3000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF4D), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF4D), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D_NICKNAME), string(STR_RELDEC_MEDIUM, 14));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/diesel/df4d4000.pnml
+++ b/src/diesel/df4d4000.pnml
@@ -93,7 +93,7 @@ item (FEAT_TRAINS, df4d4000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4D), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D4000_LIVERY_AVAILABILITY), string(STR_DF4D_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4D), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D4000_LIVERY_AVAILABILITY), string(STR_DF4D_NICKNAME), string(STR_RELDEC_MEDIUM, 14));
         cargo_subtype_text:             switch_df4d4000_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4d7000.pnml
+++ b/src/diesel/df4d7000.pnml
@@ -71,7 +71,7 @@ item (FEAT_TRAINS, df4d7000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF4D7000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D7000_NICKNAME), string(STR_RELIABILITY_10));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF4D7000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4D7000_NICKNAME), string(STR_RELDEC_LOW, 10));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/diesel/df4df.pnml
+++ b/src/diesel/df4df.pnml
@@ -85,7 +85,7 @@ item (FEAT_TRAINS, df4df) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4DF), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_DF4DF_LIVERY_AVAILABILITY), string(STR_DF4D_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4DF), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_DF4DF_LIVERY_AVAILABILITY), string(STR_DF4D_NICKNAME), string(STR_RELDEC_MEDIUM, 16));
         cargo_subtype_text:             switch_df4df_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4e.pnml
+++ b/src/diesel/df4e.pnml
@@ -83,7 +83,7 @@ item (FEAT_TRAINS, df4e) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF4E), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF4E), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_MEDIUM, 14));
         cargo_subtype_text:             switch_df4e_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4h.pnml
+++ b/src/diesel/df4h.pnml
@@ -72,7 +72,7 @@ item (FEAT_TRAINS, df4h) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4_NICKNAME), string(STR_RELIABILITY_32));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4_NICKNAME), string(STR_RELDEC_VERY_HIGH, 32));
         cargo_subtype_text:             switch_df4h_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df4k.pnml
+++ b/src/diesel/df4k.pnml
@@ -129,7 +129,7 @@ item (FEAT_TRAINS, df4k) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4_NICKNAME), string(STR_RELIABILITY_32));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF4), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF4_LIVERY_AVAILABILITY), string(STR_DF4_NICKNAME), string(STR_RELDEC_VERY_HIGH, 32));
         cargo_subtype_text:             switch_df4k_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df5.pnml
+++ b/src/diesel/df5.pnml
@@ -95,7 +95,7 @@ item (FEAT_TRAINS, df5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_MEDIUM, 16));
         cargo_subtype_text:             switch_df5_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df5kz.pnml
+++ b/src/diesel/df5kz.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, df5kz) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF5KZ), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_20));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_DF5KZ), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_HIGH, 20));
         cargo_subtype_text:             switch_df5kz_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df7g.pnml
+++ b/src/diesel/df7g.pnml
@@ -67,7 +67,7 @@ item (FEAT_TRAINS, df7g) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF7G), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF7G_NICKNAME), string(STR_RELIABILITY_20));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF7G), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF7G_NICKNAME), string(STR_RELDEC_HIGH, 20));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_df7g_graphics;

--- a/src/diesel/df7g5000.pnml
+++ b/src/diesel/df7g5000.pnml
@@ -82,7 +82,7 @@ item (FEAT_TRAINS, df7g5000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF7G), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF7G5000_LIVERY_AVAILABILITY), string(STR_DF7G_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF7G), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF7G5000_LIVERY_AVAILABILITY), string(STR_DF7G_NICKNAME), string(STR_RELDEC_MEDIUM, 16));
         cargo_subtype_text:             switch_df7g5000_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/df7g8000.pnml
+++ b/src/diesel/df7g8000.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, df7g8000) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF7G8000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF7G_NICKNAME), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DF7G8000), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF7G_NICKNAME), string(STR_RELDEC_MEDIUM, 16));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_df7g8000_graphics;

--- a/src/diesel/df8b.pnml
+++ b/src/diesel/df8b.pnml
@@ -77,7 +77,7 @@ item (FEAT_TRAINS, df8b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF8B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF8B_LIVERY_AVAILABILITY), string(STR_DF8B_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_5, string(STR_FULL_NAME_DF8B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_DF8B_LIVERY_AVAILABILITY), string(STR_DF8B_NICKNAME), string(STR_RELDEC_MEDIUM, 14));
         cargo_subtype_text:             switch_df8b_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/dfh7.pnml
+++ b/src/diesel/dfh7.pnml
@@ -87,7 +87,7 @@ item (FEAT_TRAINS, dfh7) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DFH7), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_24));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_DFH7), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_HIGH, 24));
         cargo_subtype_text:             switch_dfh7_cargo_subtype;
         can_attach_wagon:               locowagon;
         // Graphics

--- a/src/diesel/hxn3.pnml
+++ b/src/diesel/hxn3.pnml
@@ -87,7 +87,7 @@ item (FEAT_TRAINS, hxn3) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_HXN3), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_HXN3), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_LOW, 8));
         cargo_subtype_text:             switch_hxn3_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/hxn3qz.pnml
+++ b/src/diesel/hxn3qz.pnml
@@ -110,7 +110,7 @@ item (FEAT_TRAINS, hxn3qz) {
     }
     graphics {
         // Menu
-        additional_text:                        string(STR_DESC_3, string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_8), string(STR_HXN3QZ_CONSIST));
+        additional_text:                        string(STR_DESC_3, string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_LOW, 8), string(STR_HXN3QZ_CONSIST));
         can_attach_wagon:                       locowagon;
         cargo_subtype_text:                     switch_hxn3qz_cargo_subtype;
 

--- a/src/diesel/hxn5.pnml
+++ b/src/diesel/hxn5.pnml
@@ -81,7 +81,7 @@ item (FEAT_TRAINS, hxn5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXN5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXN5_NICKNAME), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXN5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXN5_NICKNAME), string(STR_RELDEC_LOW, 8));
         cargo_subtype_text:             switch_hxn5_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/hxn5b.pnml
+++ b/src/diesel/hxn5b.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, hxn5b) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXN5B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXN5B_NICKNAME), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_4, string(STR_FULL_NAME_HXN5B), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_HXN5B_NICKNAME), string(STR_RELDEC_MEDIUM, 14));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_hxn5b_graphics;

--- a/src/diesel/nd5.pnml
+++ b/src/diesel/nd5.pnml
@@ -88,7 +88,7 @@ item (FEAT_TRAINS, nd5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_ND5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_14));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_ND5), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_MEDIUM, 14));
         cargo_subtype_text:             switch_nd5_cargo_subtype;
         can_attach_wagon:               locowagon;
 

--- a/src/diesel/nj2.pnml
+++ b/src/diesel/nj2.pnml
@@ -113,7 +113,7 @@ item (FEAT_TRAINS, nj2) {
     }
     graphics {
         // Menu
-        additional_text:                        string(STR_DESC_5, string(STR_US_IMPORT), string(STR_NJ2_LIVERY_AVAILABILITY), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_8), string(STR_NJ2_CONSIST));
+        additional_text:                        string(STR_DESC_5, string(STR_US_IMPORT), string(STR_NJ2_LIVERY_AVAILABILITY), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_LOW, 8), string(STR_NJ2_CONSIST));
         can_attach_wagon:                       locowagon;
         cargo_subtype_text:                     switch_nj2_cargo_subtype;
 

--- a/src/dmu/nc3.pnml
+++ b/src/dmu/nc3.pnml
@@ -210,7 +210,7 @@ item (FEAT_TRAINS, nc3) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_5, string(STR_NC3_CAN_ATTACH_WAGON), string(STR_NC3_CONSIST), string(STR_HU_IMPORT), string(STR_COMFORT, 185), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_5, string(STR_NC3_CAN_ATTACH_WAGON), string(STR_NC3_CONSIST), string(STR_HU_IMPORT), string(STR_COMFORT_MEDIUM, 185), string(STR_RELDEC_MEDIUM, 16));
         can_attach_wagon:               onlyze;
         start_stop:                     mu2to16car;
 

--- a/src/dmu/ndj3.pnml
+++ b/src/dmu/ndj3.pnml
@@ -124,7 +124,7 @@ item (FEAT_TRAINS, ndj3) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_NDJ3_NICKNAME), string(STR_NDJ3_CAN_ATTACH_WAGON), string(STR_NDJ3_CONSIST), string(STR_RELIABILITY_6));
+        additional_text:                string(STR_DESC_4, string(STR_NDJ3_NICKNAME), string(STR_NDJ3_CAN_ATTACH_WAGON), string(STR_NDJ3_CONSIST), string(STR_RELDEC_VERY_LOW, 6));
         can_attach_wagon:               ndj3wagon;
         start_stop:                     switch_ndj3_start_stop;
 

--- a/src/dmu/nzj1_xinshuguang.pnml
+++ b/src/dmu/nzj1_xinshuguang.pnml
@@ -110,7 +110,7 @@ item (FEAT_TRAINS, nzj1_xinshuguang) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_NZJ1_XINSHUGUANG_CAN_ATTACH_WAGON), string(STR_NZJ1_XINSHUGUANG_CONSIST), string(STR_RELIABILITY_16));
+        additional_text:                string(STR_DESC_3, string(STR_NZJ1_XINSHUGUANG_CAN_ATTACH_WAGON), string(STR_NZJ1_XINSHUGUANG_CONSIST), string(STR_RELDEC_MEDIUM, 16));
         can_attach_wagon:               nzj1_xinshuguang_wagon;
         start_stop:                     switch_nzj1_xinshuguang_start_stop;
 

--- a/src/dmu/nzj2_jinlun_double_decker.pnml
+++ b/src/dmu/nzj2_jinlun_double_decker.pnml
@@ -94,7 +94,7 @@ item (FEAT_TRAINS, nzj2_jinlun_2) {
     }
     graphics {
         // Menu
-        additional_text:                        string(STR_DESC_3, string(STR_JINLUN_LOCOMOTIVE_CONSIST), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_RELIABILITY_20));
+        additional_text:                        string(STR_DESC_3, string(STR_JINLUN_LOCOMOTIVE_CONSIST), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_RELDEC_HIGH, 20));
         can_attach_wagon:                       switch_nzj2_jinlun_2_can_attach_wagon;
         start_stop:                             switch_nzj2_jinlun_2_start_stop;
         // Graphics

--- a/src/dmu/nzj2_jinlun_unilaminar.pnml
+++ b/src/dmu/nzj2_jinlun_unilaminar.pnml
@@ -91,7 +91,7 @@ item (FEAT_TRAINS, nzj2_jinlun_1) {
     }
     graphics {
         // Menu
-        additional_text:                        string(STR_DESC_3, string(STR_JINLUN_LOCOMOTIVE_CONSIST), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_RELIABILITY_20));
+        additional_text:                        string(STR_DESC_3, string(STR_JINLUN_LOCOMOTIVE_CONSIST), string(STR_ELECTRICITY_SUPPLY_YES), string(STR_RELDEC_HIGH, 20));
         can_attach_wagon:                       switch_nzj2_jinlun_1_can_attach_wagon;
         start_stop:                             switch_nzj2_jinlun_1_start_stop;
         // Graphics

--- a/src/multipower-loco/cha1c.pnml
+++ b/src/multipower-loco/cha1c.pnml
@@ -91,7 +91,7 @@ item (FEAT_TRAINS, cha1c) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_4, string(STR_CHA1C_DESC),string(STR_ELECTRICITY_SUPPLY_YES), string(STR_RELIABILITY_8));
+        additional_text:                string(STR_DESC_4, string(STR_CHA1C_DESC),string(STR_ELECTRICITY_SUPPLY_YES), string(STR_RELDEC_LOW, 8));
         can_attach_wagon:               locowagon;
         // Graphics
         default:                        switch_cha1c_graphics;

--- a/src/steam/sy.pnml
+++ b/src/steam/sy.pnml
@@ -68,7 +68,7 @@ item (FEAT_TRAINS, sy) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SY), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELIABILITY_12));
+        additional_text:                string(STR_DESC_3, string(STR_FULL_NAME_SY), string(STR_ELECTRICITY_SUPPLY_NO), string(STR_RELDEC_LOW, 12));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/unit-wagons-rail/swmuw.pnml
+++ b/src/unit-wagons-rail/swmuw.pnml
@@ -49,7 +49,7 @@ item (FEAT_TRAINS, swmuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_720));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_VERY_HIGH, 720));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/wemuw.pnml
+++ b/src/unit-wagons-rail/wemuw.pnml
@@ -50,7 +50,7 @@ item (FEAT_TRAINS, wemuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_CR200J), string(STR_COMFORT_480));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_CR200J), string(STR_COMFORT_HIGH, 480));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/wgmuw.pnml
+++ b/src/unit-wagons-rail/wgmuw.pnml
@@ -50,7 +50,7 @@ item (FEAT_TRAINS, wgmuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_SLEEPER_MU), string(STR_COMFORT_800));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_SLEEPER_MU), string(STR_COMFORT_VERY_HIGH, 800));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/wymuw.pnml
+++ b/src/unit-wagons-rail/wymuw.pnml
@@ -50,7 +50,7 @@ item (FEAT_TRAINS, wymuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_SLEEPER_MU), string(STR_COMFORT_640));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_SLEEPER_MU), string(STR_COMFORT_VERY_HIGH, 640));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/zecmuw.pnml
+++ b/src/unit-wagons-rail/zecmuw.pnml
@@ -51,7 +51,7 @@ item (FEAT_TRAINS, zecmuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_3, string(STR_CAFE_EFFECT), string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_240_CAFE));
+        additional_text:                string(STR_DESC_3, string(STR_CAFE_EFFECT), string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_HIGH, 300));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/zemuw.pnml
+++ b/src/unit-wagons-rail/zemuw.pnml
@@ -62,7 +62,7 @@ item (FEAT_TRAINS, zemuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_240));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_MEDIUM, 240));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/zsmuw.pnml
+++ b/src/unit-wagons-rail/zsmuw.pnml
@@ -50,7 +50,7 @@ item (FEAT_TRAINS, zsmuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_640));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_VERY_HIGH, 640));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/unit-wagons-rail/zymuw.pnml
+++ b/src/unit-wagons-rail/zymuw.pnml
@@ -50,7 +50,7 @@ item (FEAT_TRAINS, zymuw) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_400));
+        additional_text:                string(STR_DESC_2, string(STR_ATTACH_ALL_CRH_CR), string(STR_COMFORT_HIGH, 400));
         can_attach_wagon:               muhead;
 
         // Graphics

--- a/src/wagons/b22.pnml
+++ b/src/wagons/b22.pnml
@@ -85,7 +85,7 @@ item (FEAT_TRAINS, b22) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_1600);
+        additional_text:                string(STR_FRESHNESS_EXTREMELY_HIGH, 1600);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/b6.pnml
+++ b/src/wagons/b6.pnml
@@ -78,7 +78,7 @@ item (FEAT_TRAINS, b6) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_800);
+        additional_text:                string(STR_FRESHNESS_VERY_HIGH, 800);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/c62.pnml
+++ b/src/wagons/c62.pnml
@@ -97,7 +97,7 @@ item (FEAT_TRAINS, c62) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_C62_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_C62_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/c64.pnml
+++ b/src/wagons/c64.pnml
@@ -99,7 +99,7 @@ item (FEAT_TRAINS, c64) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_C64_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_C64_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/c70.pnml
+++ b/src/wagons/c70.pnml
@@ -125,7 +125,7 @@ item (FEAT_TRAINS, c70) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_C70_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_C70_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/g17.pnml
+++ b/src/wagons/g17.pnml
@@ -84,7 +84,7 @@ item (FEAT_TRAINS, g17) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_G17_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_G17_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/g50.pnml
+++ b/src/wagons/g50.pnml
@@ -67,7 +67,7 @@ item (FEAT_TRAINS, g50) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_185);
+        additional_text:                string(STR_FRESHNESS_MEDIUM, 185);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/g60.pnml
+++ b/src/wagons/g60.pnml
@@ -74,7 +74,7 @@ item (FEAT_TRAINS, g60) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_G60_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_G60_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/gn70.pnml
+++ b/src/wagons/gn70.pnml
@@ -78,7 +78,7 @@ item (FEAT_TRAINS, gn70) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_GN70_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_GN70_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/gn80.pnml
+++ b/src/wagons/gn80.pnml
@@ -74,7 +74,7 @@ item (FEAT_TRAINS, gn80) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_GN80_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_GN80_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/j5.pnml
+++ b/src/wagons/j5.pnml
@@ -93,7 +93,7 @@ item (FEAT_TRAINS, j5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_800);
+        additional_text:                string(STR_FRESHNESS_VERY_HIGH, 800);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/jsq5.pnml
+++ b/src/wagons/jsq5.pnml
@@ -74,7 +74,7 @@ item (FEAT_TRAINS, jsq5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_400);
+        additional_text:                string(STR_FRESHNESS_HIGH, 400);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/jsq6.pnml
+++ b/src/wagons/jsq6.pnml
@@ -77,7 +77,7 @@ item (FEAT_TRAINS, jsq6) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_400);
+        additional_text:                string(STR_FRESHNESS_HIGH, 400);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/l70.pnml
+++ b/src/wagons/l70.pnml
@@ -69,7 +69,7 @@ item (FEAT_TRAINS, l70) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DECAY_185);
+        additional_text:                string(STR_FRESHNESS_MEDIUM, 185);
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/n5.pnml
+++ b/src/wagons/n5.pnml
@@ -172,7 +172,7 @@ item (FEAT_TRAINS, n5) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_N5_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_N5_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/n60.pnml
+++ b/src/wagons/n60.pnml
@@ -93,7 +93,7 @@ item (FEAT_TRAINS, n60) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_N60_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_N60_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/nx17.pnml
+++ b/src/wagons/nx17.pnml
@@ -1146,7 +1146,7 @@ item (FEAT_TRAINS, nx17) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_NX17_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_NX17_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics

--- a/src/wagons/nx70a.pnml
+++ b/src/wagons/nx70a.pnml
@@ -605,7 +605,7 @@ item (FEAT_TRAINS, nx70a) {
     }
     graphics {
         // Menu
-        additional_text:                string(STR_DESC_2, string(STR_NX70A_LIVERY_AVAILABILITY), string(STR_DECAY_185));
+        additional_text:                string(STR_DESC_2, string(STR_NX70A_LIVERY_AVAILABILITY), string(STR_FRESHNESS_MEDIUM, 185));
         can_attach_wagon:               locowagon;
 
         // Graphics


### PR DESCRIPTION
Till now, the language strings for reliability decay speed and cargo age period (comfort/freshness/whatever) are still in form without commas. This would extend at least three problems:

1. Increase the number of language strings - remember it is not infinite;
2. It is more complex to add new reldec and comfort values - you would add a string in every language file;
3. For new players, they are not familiar with these mechanics, and thus would wonder how on earth these values work.

In this PR, these language strings are unified as forms with commas (and thus can type whatever values), and are categorised into 5 or 6 types with different colours:

Reliability decay speed:
- very high (>=25), red;
- high ([19, 24]), orange;
- medium ([13, 18]), yellow;
- low ([7, 12]), green;
- very low ([1, 6]), blue.

Cargo age period:
- extremely high (>=1000), white;
- very high ([500, 999]), blue;
- high ([275, 499]), green;
- medium ([180, 274]), yellow;
- low ([130, 179]), orange;
- very low ([80, 129]), red.

Potential drawbacks:
- Unfriendly to color-blind people? (But there are texts)
- It is an extra work to write language strings for e.g. "Peng Dai Ke" (Passengers in Boxcars), or other wagons with comfort values vary by cargotypes. Since comfort values should be colored.

But I think it does much more good than harm.