### PR TITLE
Update: build and release workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,12 @@
-name: Build
+name: Release
+
+permissions:
+  contents: write
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
+    tags:
+      - "*.*.*"
   workflow_dispatch:
 
 jobs:
@@ -29,7 +29,6 @@ jobs:
             scoop install openttd/gorender
             make
 
-      - uses: actions/upload-artifact@v4
+      - uses: softprops/action-gh-release@v2
         with:
-          name: chinasettrains.grf
-          path: chinasettrains.grf
+          files: chinasettrains.grf


### PR DESCRIPTION
Adds "upload artifact" in the regular build workflow and adds a release workflow.

ref: <https://github.com/WenSimEHRP/jppluswins>, check the "Actions" tab.

### Regular build workflow

GitHub will build the GRF and store it for 90 days upon commit pushes.

### Release workflow

GitHub will build the GRF and release it upon tag pushes. The tag must follow the format "0.0.0" - no leading v's and no trailing revisions, simply three numbers seperated by two periods.

We might even want to add a function to automatically push the GRF to BaNaNaS. (i.e., a bunch of `curl -X -H` stacked together)