### PR TITLE
Update: make GitHub Actions build faster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,4 +32,4 @@ jobs:
             scoop bucket add openttd https://github.com/WenSimEHRP/OpenTTD-Bucket
             scoop install openttd/nml
             scoop install openttd/gorender
-            make
+            make -j 10


### PR DESCRIPTION
Currently GitHub Actions has no "cache", so each time it builds, it has to render all voxel models from scratch.
By commanding "make -j 10" instead of just "make", it could render up to 10 voxel models instead of just 1 at the same time, thus shortening the time of GitHub Actions building.