### PR TITLE
Docs: remove make multithread comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ pip3 install nml
 
 # compiling
 make
-# alternatively, you could use "make -j n" where n is the total number of parallel tasks you want to run at once.
 ```
 
 Using Windows (Scoop is advised here, but non-scoop compilations are also possible):
@@ -87,7 +86,6 @@ scoop install mingw
 
 # compiling
 make
-# alternatively, you could use "make -j n" where n is the total number of parallel tasks you want to run at once.
 ```
 
 ## 3. Credits


### PR DESCRIPTION
Gorender itself is already multithreaded, so adding make -j n doesnt' help.
