### PR TITLE
add "has cab" flag to MU wagons for new reversing feature

### DIFF
--- a/src/25-emu/cr200jcl.pnml
+++ b/src/25-emu/cr200jcl.pnml
@@ -9,7 +9,7 @@ switch (FEAT_TRAINS, SELF, switch_cr200jcl_name, getbits(extra_callback_info1, 0
 
 // Purchase Menu
 spriteset (spriteset_cr200jcl_purchase_original, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP) {
-    template_purchase ("25-emu\cr200jc", "cr200jc-m")
+    template_purchase ("25-emu/cr200jc", "cr200jc-m")
 }
 
 // Vehicle

--- a/src/unit-wagons-rail/kymuw.pnml
+++ b/src/unit-wagons-rail/kymuw.pnml
@@ -32,6 +32,7 @@ item (FEAT_TRAINS, kymuw) {
         name:                           string(STR_NAME_KYMUW);
         sprite_id:                      SPRITE_ID_NEW_TRAIN;
         misc_flags:                     bitmask(TRAIN_FLAG_AUTOREFIT);
+        extra_flags:                    bitmask(VEHICLE_FLAG_TRAIN_HAS_CAB);
         variant_group:					zemuw;
 
         // Availability

--- a/src/unit-wagons-rail/swmuw.pnml
+++ b/src/unit-wagons-rail/swmuw.pnml
@@ -19,6 +19,7 @@ item (FEAT_TRAINS, swmuw) {
         name:                           string(STR_NAME_SWMUW);
         sprite_id:                      SPRITE_ID_NEW_TRAIN;
         misc_flags:                     bitmask(TRAIN_FLAG_AUTOREFIT);
+        extra_flags:                    bitmask(VEHICLE_FLAG_TRAIN_HAS_CAB);
         variant_group:					1024;
         // Availability
         climates_available:             ALL_CLIMATES;

--- a/src/unit-wagons-rail/wemuw.pnml
+++ b/src/unit-wagons-rail/wemuw.pnml
@@ -19,6 +19,7 @@ item (FEAT_TRAINS, wemuw) {
         name:                           string(STR_NAME_WEMUW);
         sprite_id:                      SPRITE_ID_NEW_TRAIN;
         misc_flags:                     bitmask(TRAIN_FLAG_AUTOREFIT);
+        extra_flags:                    bitmask(VEHICLE_FLAG_TRAIN_HAS_CAB);
         variant_group:					1024;
 
         // Availability

--- a/src/unit-wagons-rail/wgmuw.pnml
+++ b/src/unit-wagons-rail/wgmuw.pnml
@@ -19,6 +19,7 @@ item (FEAT_TRAINS, wgmuw) {
         name:                           string(STR_NAME_WGMUW);
         sprite_id:                      SPRITE_ID_NEW_TRAIN;
         misc_flags:                     bitmask(TRAIN_FLAG_AUTOREFIT);
+        extra_flags:                    bitmask(VEHICLE_FLAG_TRAIN_HAS_CAB);
         variant_group:					1024;
 
         // Availability

--- a/src/unit-wagons-rail/wymuw.pnml
+++ b/src/unit-wagons-rail/wymuw.pnml
@@ -19,6 +19,7 @@ item (FEAT_TRAINS, wymuw) {
         name:                           string(STR_NAME_WYMUW);
         sprite_id:                      SPRITE_ID_NEW_TRAIN;
         misc_flags:                     bitmask(TRAIN_FLAG_AUTOREFIT);
+        extra_flags:                    bitmask(VEHICLE_FLAG_TRAIN_HAS_CAB);
         variant_group:					1024;
 
         // Availability

--- a/src/unit-wagons-rail/zecmuw.pnml
+++ b/src/unit-wagons-rail/zecmuw.pnml
@@ -19,6 +19,7 @@ item (FEAT_TRAINS, zecmuw) {
         name:                           string(STR_NAME_ZECMUW);
         sprite_id:                      SPRITE_ID_NEW_TRAIN;
         misc_flags:                     bitmask(TRAIN_FLAG_AUTOREFIT);
+        extra_flags:                    bitmask(VEHICLE_FLAG_TRAIN_HAS_CAB);
         variant_group:					1024;
 
         // Availability

--- a/src/unit-wagons-rail/zemuw.pnml
+++ b/src/unit-wagons-rail/zemuw.pnml
@@ -32,6 +32,7 @@ item (FEAT_TRAINS, zemuw) {
         name:                           string(STR_NAME_ZEMUW);
         sprite_id:                      SPRITE_ID_NEW_TRAIN;
         misc_flags:                     bitmask(TRAIN_FLAG_AUTOREFIT);
+        extra_flags:                    bitmask(VEHICLE_FLAG_TRAIN_HAS_CAB);
 
         // Availability
         climates_available:             ALL_CLIMATES;

--- a/src/unit-wagons-rail/zsmuw.pnml
+++ b/src/unit-wagons-rail/zsmuw.pnml
@@ -19,6 +19,7 @@ item (FEAT_TRAINS, zsmuw) {
         name:                           string(STR_NAME_ZSMUW);
         sprite_id:                      SPRITE_ID_NEW_TRAIN;
         misc_flags:                     bitmask(TRAIN_FLAG_AUTOREFIT);
+        extra_flags:                    bitmask(VEHICLE_FLAG_TRAIN_HAS_CAB);
         variant_group:					1024;
 
         // Availability

--- a/src/unit-wagons-rail/zymuw.pnml
+++ b/src/unit-wagons-rail/zymuw.pnml
@@ -19,6 +19,7 @@ item (FEAT_TRAINS, zymuw) {
         name:                           string(STR_NAME_ZYMUW);
         sprite_id:                      SPRITE_ID_NEW_TRAIN;
         misc_flags:                     bitmask(TRAIN_FLAG_AUTOREFIT);
+        extra_flags:                    bitmask(VEHICLE_FLAG_TRAIN_HAS_CAB);
         variant_group:					1024;
 
         // Availability

--- a/src/wagons/dq35.pnml
+++ b/src/wagons/dq35.pnml
@@ -4,33 +4,33 @@
 
 // Purchase Menu
 spriteset (spriteset_dq35_purchase, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP) {
-    template_purchase ("wagons\dq35", "dq35-purchase")
+    template_purchase ("wagons/dq35", "dq35-purchase")
 }
 
 // Vehicle
 /* spriteset (spriteset_dq35_a, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP) {
-    template_speciel_0 ("wagons\dq35", "dq35-a")
+    template_speciel_0 ("wagons/dq35", "dq35-a")
 }
 spriteset (spriteset_dq35_b, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP) {
-    template_speciel_0 ("wagons\dq35", "dq35-b")
+    template_speciel_0 ("wagons/dq35", "dq35-b")
 } */
 spriteset (spriteset_dq35_cargo, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP) {
-    template_speciel_0 ("wagons\dq35", "dq35-cargo")
+    template_speciel_0 ("wagons/dq35", "dq35-cargo")
 }
 /* spriteset (spriteset_dq35_c, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP) {
-    template_speciel_0 ("wagons\dq35", "dq35-c")
+    template_speciel_0 ("wagons/dq35", "dq35-c")
 }
 spriteset (spriteset_dq35_d, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP) {
-    template_speciel_0 ("wagons\dq35", "dq35-d")
+    template_speciel_0 ("wagons/dq35", "dq35-d")
 } */
 spriteset (spriteset_dq35_nx17, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP) {
-    template_speciel_0 ("wagons\dq35", "dq35-nx17")
+    template_speciel_0 ("wagons/dq35", "dq35-nx17")
 }
 spriteset (spriteset_dq35_front, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP) {
-    template_speciel_0 ("wagons\dq35", "dq35-front")
+    template_speciel_0 ("wagons/dq35", "dq35-front")
 }
 spriteset (spriteset_dq35_back, ZOOM_LEVEL_IN_4X, BIT_DEPTH_32BPP) {
-    template_speciel_0 ("wagons\dq35", "dq35-back")
+    template_speciel_0 ("wagons/dq35", "dq35-back")
 }
 
 switch (FEAT_TRAINS, SELF, switch_dq35_articulated_part, extra_callback_info1) {


### PR DESCRIPTION
The new version of OpenTTD has a new reversing feature. As a side effect, Multiple Units in the current China Set under the new feature can only reverse in a very slow speed, which is unintended.

This PR adds "has cab" flag to MU wagons to ensure them reversing in full speed.

This should not affect compatibility of game versions (new flags automatically omitted by old game versions), but might need NML >=0.9.0 to compile that.